### PR TITLE
Modernize projects bento grid and full-screen skills page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,9 +7,11 @@ import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
 
 export default function AboutPage() {
   return (
-    <div className="max-w-5xl mx-auto mt-8 px-4">
+    <div className="w-screen h-[calc(100vh-4rem)] -mx-4 -mt-6 relative overflow-hidden">
+      <Skills3DWrapper />
+
       <motion.div
-        className="mb-8 text-center"
+        className="absolute top-6 left-0 right-0 z-10 text-center pointer-events-none"
         initial="hidden"
         animate="visible"
         variants={fadeInUp}
@@ -19,22 +21,20 @@ export default function AboutPage() {
           Skills
         </h2>
         <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
-        <p className="mt-4 text-sm text-muted-foreground font-mono">
+        <p className="mt-2 text-sm text-muted-foreground font-mono">
           Drag to orbit. Click a card to inspect.
         </p>
       </motion.div>
 
-      <Skills3DWrapper />
-
       <motion.div
-        className="flex items-center justify-center gap-3 mt-8 pb-8"
+        className="absolute bottom-6 left-0 right-0 z-10 flex items-center justify-center gap-3 pointer-events-auto"
         initial="hidden"
-        whileInView="visible"
+        animate="visible"
         variants={fadeInUp}
-        transition={DEFAULT_TRANSITION}
+        transition={{ ...DEFAULT_TRANSITION, delay: 0.3 }}
       >
         <span className="font-mono text-sm text-muted-foreground">
-          To know more about me, check the social links below or
+          Check the social links or
         </span>
         <ResumeButton fileLink={process.env.NEXT_PUBLIC_RESUME_LINK ?? ""} />
       </motion.div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,19 +1,88 @@
+"use client";
 
-import ProjectCard from '@/components/ProjectCard/ProjectCard';
-import { PROJECTS } from '@/constants/projects';
-import React from 'react'
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { PROJECTS } from "@/constants/projects";
+import ProjectCardModern from "@/components/ProjectCard/ProjectCardModern";
+import { staggerContainer, fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
 
-const ProjectsPage = () => {
-    return (
-        <div className="max-w-4xl mt-8 flex flex-col items-start justify-start">
-            <h2 className="text-2xl font-semibold font-mono text-primary mb-4">My Projects</h2>
-            <div className='projects flex flex-col gap-4'>
-                {PROJECTS.map((project, index) => (
-                    <ProjectCard project={project} key={index} />
-                ))}
-            </div>
-        </div >
-    )
+const CATEGORIES = ["all", "web", "blockchain", "tools", "game"] as const;
+
+export default function ProjectsPage() {
+  const [filter, setFilter] = useState("all");
+
+  const featured = PROJECTS.filter((p) => p.featured);
+  const filtered =
+    filter === "all"
+      ? PROJECTS.filter((p) => !p.featured)
+      : PROJECTS.filter((p) => p.category === filter && !p.featured);
+
+  return (
+    <div className="max-w-6xl mx-auto w-full mt-8">
+      <motion.div
+        className="mb-10 text-center"
+        initial="hidden"
+        animate="visible"
+        variants={fadeInUp}
+        transition={DEFAULT_TRANSITION}
+      >
+        <h2 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
+          My Projects
+        </h2>
+        <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
+      </motion.div>
+
+      <motion.div
+        className="flex flex-wrap justify-center gap-2 mb-8"
+        initial="hidden"
+        animate="visible"
+        variants={fadeInUp}
+        transition={{ ...DEFAULT_TRANSITION, delay: 0.1 }}
+      >
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setFilter(cat)}
+            className={`px-4 py-1.5 rounded-full text-xs font-mono font-semibold uppercase tracking-wider border transition-all duration-200 ${
+              filter === cat
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-transparent text-muted-foreground border-border hover:border-primary/40 hover:text-primary"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </motion.div>
+
+      {filter === "all" && featured.length > 0 && (
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8"
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+        >
+          {featured.map((project) => (
+            <ProjectCardModern
+              key={project.name}
+              project={project}
+              className="min-h-[260px]"
+            />
+          ))}
+        </motion.div>
+      )}
+
+      <motion.div
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+      >
+        <AnimatePresence mode="popLayout">
+          {filtered.map((project) => (
+            <ProjectCardModern key={project.name} project={project} />
+          ))}
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  );
 }
-
-export default ProjectsPage;

--- a/components/ProjectCard/ProjectCardModern.tsx
+++ b/components/ProjectCard/ProjectCardModern.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Code2Icon, EarthIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { openLink } from "@/lib/utils";
+import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
+import type { Project } from "@/types";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  web: "#3b82f6",
+  blockchain: "#8b5cf6",
+  tools: "#f59e0b",
+  game: "#10b981",
+};
+
+interface ProjectCardModernProps {
+  project: Project;
+  className?: string;
+}
+
+export default function ProjectCardModern({ project, className = "" }: ProjectCardModernProps) {
+  const { name, stack, description, githubLink, websiteLink, category } = project;
+  const accentColor = CATEGORY_COLORS[category ?? "web"] ?? "#3b82f6";
+  const techPills = stack.split("|").map((t) => t.trim()).filter(Boolean);
+
+  return (
+    <motion.div
+      className={`group relative rounded-xl border border-border/50 bg-card/50 backdrop-blur-md overflow-hidden hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300 hover:-translate-y-1 flex flex-col ${className}`}
+      variants={fadeInUp}
+      transition={DEFAULT_TRANSITION}
+      layout
+    >
+      <div
+        className="h-[3px] w-full"
+        style={{ background: `linear-gradient(90deg, ${accentColor}, transparent)` }}
+      />
+
+      <div className="p-5 flex flex-col flex-1 gap-3">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="font-mono font-bold text-base text-primary leading-tight">
+            {name}
+          </h3>
+          {category && (
+            <span
+              className="shrink-0 text-[10px] font-mono font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full border"
+              style={{
+                color: accentColor,
+                borderColor: accentColor,
+                backgroundColor: `${accentColor}10`,
+              }}
+            >
+              {category}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {techPills.map((tech) => (
+            <span
+              key={tech}
+              className="text-[11px] font-mono px-2 py-0.5 rounded-md bg-muted text-muted-foreground"
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted-foreground leading-relaxed line-clamp-3 flex-1">
+          {description}
+        </p>
+
+        <div className="flex gap-2 pt-1">
+          {githubLink && githubLink.length > 0 && (
+            <Button
+              onClick={() => openLink(githubLink)}
+              variant="ghost"
+              size="sm"
+              className="font-mono text-xs h-8 px-3 hover:bg-muted"
+            >
+              <Code2Icon className="w-3.5 h-3.5 mr-1.5" /> Code
+            </Button>
+          )}
+          {websiteLink && websiteLink.length > 0 && (
+            <Button
+              onClick={() => openLink(websiteLink)}
+              variant="ghost"
+              size="sm"
+              className="font-mono text-xs h-8 px-3 hover:bg-muted"
+            >
+              <EarthIcon className="w-3.5 h-3.5 mr-1.5" /> Live
+            </Button>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/skills/Skills3DWrapper.tsx
+++ b/components/skills/Skills3DWrapper.tsx
@@ -7,7 +7,7 @@ import SkillsFallback from "./SkillsFallback";
 const SkillsScene = dynamic(() => import("./SkillsScene"), {
   ssr: false,
   loading: () => (
-    <div className="w-full h-[500px] sm:h-[600px] flex items-center justify-center">
+    <div className="w-full h-full flex items-center justify-center">
       <div className="animate-pulse text-muted-foreground font-mono text-sm">
         Loading 3D scene...
       </div>
@@ -35,7 +35,7 @@ export default function Skills3DWrapper() {
 
   if (supportsWebGL === null) {
     return (
-      <div className="w-full h-[500px] sm:h-[600px] flex items-center justify-center">
+      <div className="w-full h-full flex items-center justify-center">
         <div className="animate-pulse text-muted-foreground font-mono text-sm">
           Loading...
         </div>

--- a/components/skills/SkillsFallback.tsx
+++ b/components/skills/SkillsFallback.tsx
@@ -6,26 +6,28 @@ import { fadeInUp, staggerContainer, DEFAULT_TRANSITION, VIEWPORT_ONCE } from "@
 
 export default function SkillsFallback() {
   return (
-    <motion.div
-      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 py-8"
-      variants={staggerContainer}
-      initial="hidden"
-      whileInView="visible"
-      viewport={VIEWPORT_ONCE}
-    >
-      {skills.map((skill) => (
-        <motion.div
-          key={skill.index}
-          className="flex flex-col items-center gap-2 p-6 rounded-xl border border-border/50 bg-card/50 backdrop-blur-md hover:border-primary/30 hover:shadow-lg transition-all duration-300 hover:-translate-y-1"
-          variants={fadeInUp}
-          transition={DEFAULT_TRANSITION}
-          style={{ borderBottomColor: `rgb(${skill.color})`, borderBottomWidth: "3px" }}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={skill.logo} alt={skill.name} width={48} height={48} />
-          <span className="text-sm font-mono font-semibold text-primary">{skill.name}</span>
-        </motion.div>
-      ))}
-    </motion.div>
+    <div className="w-full h-full flex items-center justify-center p-8">
+      <motion.div
+        className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 max-w-4xl"
+        variants={staggerContainer}
+        initial="hidden"
+        whileInView="visible"
+        viewport={VIEWPORT_ONCE}
+      >
+        {skills.map((skill) => (
+          <motion.div
+            key={skill.index}
+            className="flex flex-col items-center gap-2 p-6 rounded-xl border border-border/50 bg-card/50 backdrop-blur-md hover:border-primary/30 hover:shadow-lg transition-all duration-300 hover:-translate-y-1"
+            variants={fadeInUp}
+            transition={DEFAULT_TRANSITION}
+            style={{ borderBottomColor: `rgb(${skill.color})`, borderBottomWidth: "3px" }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={skill.logo} alt={skill.name} width={48} height={48} />
+            <span className="text-sm font-mono font-semibold text-primary">{skill.name}</span>
+          </motion.div>
+        ))}
+      </motion.div>
+    </div>
   );
 }

--- a/components/skills/SkillsScene.tsx
+++ b/components/skills/SkillsScene.tsx
@@ -37,16 +37,17 @@ export default function SkillsScene() {
   const handleClose = useCallback(() => setSelected(null), []);
 
   return (
-    <div className="relative w-full h-[500px] sm:h-[600px]">
+    <div className="relative w-full h-full">
       <Canvas
-        camera={{ position: [0, 0, 12], fov: 50 }}
+        camera={{ position: [0, 0, 12], fov: 45 }}
         style={{ background: "transparent" }}
       >
         <ambientLight intensity={0.5} />
         <pointLight position={[10, 10, 10]} intensity={1} />
         <pointLight position={[-10, -10, -5]} intensity={0.5} color="#6366f1" />
+        <pointLight position={[0, -10, 5]} intensity={0.3} color="#8b5cf6" />
 
-        <Stars radius={50} depth={50} count={1500} factor={3} saturation={0} fade speed={1} />
+        <Stars radius={50} depth={50} count={3000} factor={4} saturation={0} fade speed={1} />
 
         {skills.map((skill, i) => (
           <SkillCard3D

--- a/constants/projects/index.ts
+++ b/constants/projects/index.ts
@@ -6,56 +6,65 @@ export const PROJECTS: Project[] = [
         stack: "Next.js | Faker.js | TailwindCSS",
         description: "I built this platform to simplify the process of designing and generating mock data for developers, testers, and teams working on real-world applications. Whether you're building an app, testing APIs, or need sample datasets for your projects, this tool is here to make it fast, reliable, and fully customisable.The mock data generator currently supports 26 different data categories and allows you to create nearly 200+ unique types of data, catering to diverse application and testing needs. Currently supports generation of fake data in 43 different languages.",
         githubLink: "",
-        websiteLink: "https://www.mock-data.com"
+        websiteLink: "https://www.mock-data.com",
+        category: "web",
+        featured: true,
     },
     {
         name: "DataForge - Through WebScrape workflow",
         stack: "Next.js | Puppeteer | Prisma | OpenAI",
         description: "A dataset creator for ML models through Web-scrape workflows. Allows users to create web-scraping workflows with various configuration to create web-scraping workflow to collect data for dataset. It has AI integration that allows AI to extract necessary selectors and data from website. Also has facilities to schedule the workflow to appropriate times using cron syntax. Currently can send the data through webhook. In future, In house dataset storage and marketplace for selling datasets will be implemented.",
         githubLink: "https://github.com/itsraghul/FlowBuilder",
-        websiteLink: "https://flow-data-forge.vercel.app/"
+        websiteLink: "https://flow-data-forge.vercel.app/",
+        category: "web",
+        featured: true,
     },
     {
         name: "Hearty-Foods - Food delivery app",
         stack: "Next.js | MongoDB | Cloudinary | Paypal API",
         description: "Hearty Foods is a food order and delivery site build using NextJS. It has MongoDB for data storage and Material UI for styling.User can be able to order food and see their order history.Payment can be made with cash or through Paypal.The Admin(owner) can create new dishes and administer the orders made by the users and check the total collection and all the data. It was build using several apis like JSCookies, Cloudinary, JWToken and so on for various features.",
         githubLink: "https://github.com/itsraghul/hearty-foods",
-        websiteLink: "https://hearty-foods.vercel.app/"
+        websiteLink: "https://hearty-foods.vercel.app/",
+        category: "web",
     },
     {
         name: "MediNet - Decentralized Medical Network",
         stack: "Next.js | Ethereum | Web3 | IPFS",
         description: "A Decentralized Platform that provides Patient Record Management Services and Medical Community Network for Doctors. Platform allows patient to have control over their medical record. And doctors to form their own medical networks for better patient diagnosis. The files shared in the platform are done using IPFS.",
         githubLink: "https://github.com/itsraghul/medi-net",
-        websiteLink: "https://medinet.vercel.app/"
+        websiteLink: "https://medinet.vercel.app/",
+        category: "blockchain",
     },
     {
         name: "CampFund - Decentralized Funding Network",
         stack: "Next.js | Ethereum | Solidity | Azure",
         description: "An Open-Public Project Fund Raising Site. Uses Ethereum for exchange of funds. User can create their own project fund by deploying the smart contract instance with the help of this site. The Fund Raising Contract Factory have been deployed to Rinkeby Test Network. The Users need a Metamask Account and RinkebyEther to transfer and fund cryptocoins. A Project Fund manager can create a new request for projects and need the approval of contributors.All project changes are open and seen by the contributors which prevents embezzlement.Added Azure Chat bot for customer help.",
         githubLink: "https://github.com/itsraghul/camp-fund",
-        websiteLink: "https://my-camp-fund.vercel.app/"
+        websiteLink: "https://my-camp-fund.vercel.app/",
+        category: "blockchain",
     },
     {
         name: "RS Blockchain - A miniature blockchain",
-        stack: "Javascript | Redis ",
+        stack: "Javascript | Redis",
         description: "A miniature block chain built using Javascript. It uses redis pub-sub model for blockchain transaction and mining.",
         githubLink: "https://github.com/itsraghul/rs-blockchain/",
-        websiteLink: ""
+        websiteLink: "",
+        category: "tools",
     },
     {
         name: "TriviaWebApp",
-        stack: "Javascript | HTML | CSS ",
+        stack: "Javascript | HTML | CSS",
         description: "A simple triva app that gives you random trivia quesitons. The highscores are stored in browser storage for user understanding.",
         githubLink: "https://github.com/itsraghul/TriviaWebApp",
-        websiteLink: "https://trivia-web-app.vercel.app/"
+        websiteLink: "https://trivia-web-app.vercel.app/",
+        category: "web",
     },
     {
         name: "Cosmic Breakout- Endless Runner Mobile Game",
-        stack: "GDevelop5 ",
+        stack: "GDevelop5",
         description: "A endless runner mobile game developed using GDevelop5.",
         githubLink: "https://github.com/itsraghul/CosmicBreakoutGameAndroid",
-        websiteLink: ""
+        websiteLink: "",
+        category: "game",
     },
-
-]
+];

--- a/types/index.ts
+++ b/types/index.ts
@@ -6,6 +6,8 @@ export type Project = {
     description: string;
     githubLink?: string;
     websiteLink?: string;
+    category?: string;
+    featured?: boolean;
 }
 
 


### PR DESCRIPTION
## Summary
- Replaced the plain vertical project list with a modern bento grid layout featuring category filter pills, a featured projects row, and new glassmorphism cards with gradient accents and tech stack pills
- Made the skills/about page fully immersive by expanding the 3D scene to fill the entire viewport, with title and resume button as floating overlays
- Enhanced the 3D scene with denser starfield (3000 stars), an additional purple rim light, and tighter camera FOV for a more cinematic feel

## Test plan
- [ ] Verify projects page bento grid layout at mobile, tablet, and desktop breakpoints
- [ ] Test category filter pills toggle and AnimatePresence transitions
- [ ] Verify skills page 3D scene fills the full viewport with working drag-to-orbit
- [ ] Check overlay elements (title, resume button) are positioned correctly and clickable
- [ ] Confirm dark/light mode consistency on both pages
- [ ] Run `npm run build` to ensure no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)