### PR TITLE
Fix cards, resume button, dark default, and theme-aware skills background

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { motion } from "framer-motion";
-import ResumeButton from "@/components/ResumeButton/ResumeButton";
 import Skills3DWrapper from "@/components/skills/Skills3DWrapper";
 import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
 
@@ -24,19 +23,6 @@ export default function AboutPage() {
         <p className="mt-2 text-sm text-muted-foreground font-mono">
           Drag to orbit. Click a skill to inspect.
         </p>
-      </motion.div>
-
-      <motion.div
-        className="absolute bottom-6 left-0 right-0 z-10 flex items-center justify-center gap-3 pointer-events-auto"
-        initial="hidden"
-        animate="visible"
-        variants={fadeInUp}
-        transition={{ ...DEFAULT_TRANSITION, delay: 0.3 }}
-      >
-        <span className="font-mono text-sm text-muted-foreground">
-          Check the social links or
-        </span>
-        <ResumeButton fileLink={process.env.NEXT_PUBLIC_RESUME_LINK ?? ""} />
       </motion.div>
     </div>
   );

--- a/components/landing/QuickLinks.tsx
+++ b/components/landing/QuickLinks.tsx
@@ -44,7 +44,7 @@ export default function QuickLinks() {
           >
             <Link
               href={link.href}
-              className="group flex flex-col items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-md text-center hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300 hover:-translate-y-1"
+              className="group flex flex-col items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-md text-center hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300 hover:-translate-y-1 h-full"
             >
               <link.icon className="w-8 h-8 text-muted-foreground group-hover:text-primary transition-colors mb-4" />
               <h3 className="text-lg font-bold font-mono mb-1">{link.title}</h3>

--- a/components/providers/AppProvider.tsx
+++ b/components/providers/AppProvider.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 const AppProvider = ({ children }: { children: React.ReactNode }) => {
     return (
-        <ThemeProvider attribute="class" defaultTheme='system'>
+        <ThemeProvider attribute="class" defaultTheme='dark'>
             {children}
         </ThemeProvider>
     )

--- a/components/skills/Earth.tsx
+++ b/components/skills/Earth.tsx
@@ -29,7 +29,11 @@ const glowFragmentShader = `
   }
 `;
 
-export default function Earth() {
+interface EarthProps {
+  isDark?: boolean;
+}
+
+export default function Earth({ isDark = true }: EarthProps) {
   const earthRef = useRef<THREE.Mesh>(null);
 
   const [colorMap, bumpMap] = useTexture([
@@ -39,10 +43,10 @@ export default function Earth() {
 
   const glowUniforms = useMemo(
     () => ({
-      glowColor: { value: new THREE.Color("#60a5fa") },
-      intensity: { value: 0.6 },
+      glowColor: { value: new THREE.Color(isDark ? "#60a5fa" : "#94a3b8") },
+      intensity: { value: isDark ? 0.6 : 0.3 },
     }),
-    []
+    [isDark]
   );
 
   useFrame((_, delta) => {

--- a/components/skills/SkillsScene.tsx
+++ b/components/skills/SkillsScene.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo, Suspense } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Stars, Line } from "@react-three/drei";
+import { useTheme } from "next-themes";
 import * as THREE from "three";
 import { skills } from "@/constants/about";
 import SkillCard3D from "./SkillCard3D";
@@ -60,6 +61,8 @@ function parseRgb(rgb: string): string {
 
 export default function SkillsScene() {
   const [selected, setSelected] = useState<Card | null>(null);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   const orbitConfigs = useMemo(
     () => generateOrbitConfigs(skills.length),
@@ -76,24 +79,32 @@ export default function SkillsScene() {
     <div className="relative w-full h-full rounded-xl overflow-hidden">
       <Canvas
         camera={{ position: [0, 3, 14], fov: 45 }}
-        style={{ background: "radial-gradient(ellipse at center, #0f172a 0%, #020617 70%, #000000 100%)" }}
+        style={{
+          background: isDark
+            ? "radial-gradient(ellipse at center, #0f172a 0%, #020617 70%, #000000 100%)"
+            : "radial-gradient(ellipse at center, #f8fafc 0%, #e2e8f0 70%, #cbd5e1 100%)",
+        }}
       >
         <Suspense fallback={null}>
-        <ambientLight intensity={0.4} />
-        <directionalLight position={[10, 5, 10]} intensity={0.8} />
-        <pointLight position={[-8, -5, -8]} intensity={0.3} color="#6366f1" />
+        <ambientLight intensity={isDark ? 0.4 : 0.6} />
+        <directionalLight position={[10, 5, 10]} intensity={isDark ? 0.8 : 1.0} />
+        {isDark && (
+          <pointLight position={[-8, -5, -8]} intensity={0.3} color="#6366f1" />
+        )}
 
-        <Stars
-          radius={60}
-          depth={60}
-          count={5000}
-          factor={2}
-          saturation={0}
-          fade
-          speed={0.5}
-        />
+        {isDark && (
+          <Stars
+            radius={60}
+            depth={60}
+            count={5000}
+            factor={2}
+            saturation={0}
+            fade
+            speed={0.5}
+          />
+        )}
 
-        <Earth />
+        <Earth isDark={isDark} />
 
         {skills.map((skill, i) => {
           const config = orbitConfigs[i];


### PR DESCRIPTION
## Summary
- Fix quick links card height inconsistency by adding `h-full` class
- Remove resume button and social links prompt from the about/skills page
- Default theme to dark mode instead of system preference
- Make the 3D skills scene background theme-aware: dark mode keeps the space gradient, light mode uses a neutral slate gradient; stars and indigo point light are hidden in light mode; Earth glow adapts color and intensity per theme

## Test plan
- [ ] Toggle between light and dark mode on `/about` — background, stars, and Earth glow should match each theme
- [ ] Verify quick links cards on the homepage have equal height
- [ ] Confirm resume button is no longer shown on the skills page
- [ ] Verify default theme is dark on first visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)