### PR TITLE
Add comprehensive SEO — metadata, OG image, sitemap, robots, JSON-LD

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,112 +1,33 @@
-"use client";
+import type { Metadata } from "next";
+import AboutContent from "@/components/about/AboutContent";
+import JsonLd from "@/components/JsonLd";
 
-import Image from "next/image";
-import { motion } from "framer-motion";
-import { GithubIcon, LinkedinIcon, Mail } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { openLink } from "@/lib/utils";
-import { HOMEPAGE_INFO, FEATURED_STATS } from "@/constants";
-import { fadeInUp, staggerContainer, scaleIn, DEFAULT_TRANSITION } from "@/lib/animations";
-import ProfilePortrait from "@/public/images/profile-portrait.png";
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Raghul S — Founding Software Engineer at Velt with 3+ years building across web, blockchain, and more. Get to know me.",
+  openGraph: {
+    title: "About — Raghul S",
+    description:
+      "Raghul S — Founding Software Engineer at Velt with 3+ years building across web, blockchain, and more.",
+    url: "https://raghuls.dev/about",
+  },
+};
 
-const SOCIAL_LINKS = [
-  { label: "LinkedIn", href: "https://www.linkedin.com/in/raghul-s25", icon: LinkedinIcon },
-  { label: "GitHub", href: "https://www.github.com/itsraghul", icon: GithubIcon },
-  { label: "Email", href: "mailto:raghul2521@gmail.com", icon: Mail },
-] as const;
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://raghuls.dev" },
+    { "@type": "ListItem", position: 2, name: "About", item: "https://raghuls.dev/about" },
+  ],
+};
 
 export default function AboutPage() {
   return (
-    <div className="max-w-2xl mx-auto mt-12 px-4 pb-16">
-      <motion.div
-        className="flex flex-col items-center gap-8"
-        initial="hidden"
-        animate="visible"
-        variants={staggerContainer}
-      >
-        {/* Profile image */}
-        <motion.div
-          variants={scaleIn}
-          transition={DEFAULT_TRANSITION}
-          className="relative"
-        >
-          <div className="w-36 h-36 rounded-full ring-2 ring-border bg-secondary/30 overflow-hidden">
-            <Image
-              src={ProfilePortrait}
-              alt="Raghul S"
-              width={144}
-              height={144}
-              className="object-cover w-full h-full"
-              priority
-            />
-          </div>
-        </motion.div>
-
-        {/* Name & role */}
-        <motion.div
-          className="text-center"
-          variants={fadeInUp}
-          transition={DEFAULT_TRANSITION}
-        >
-          <h1 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
-            {HOMEPAGE_INFO.NAME_INFO}
-          </h1>
-          <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
-          <p className="mt-3 text-sm font-mono text-muted-foreground">
-            {HOMEPAGE_INFO.ROLE}
-          </p>
-        </motion.div>
-
-        {/* Bio */}
-        <motion.p
-          className="text-center text-muted-foreground leading-relaxed max-w-lg"
-          variants={fadeInUp}
-          transition={DEFAULT_TRANSITION}
-        >
-          {HOMEPAGE_INFO.BASIC_DESC}
-        </motion.p>
-
-        {/* Stats */}
-        <motion.div
-          className="grid grid-cols-3 gap-4 w-full"
-          variants={fadeInUp}
-          transition={DEFAULT_TRANSITION}
-        >
-          {FEATURED_STATS.map((stat) => (
-            <div
-              key={stat.label}
-              className="flex flex-col items-center gap-1 rounded-xl border border-border/50 bg-secondary/20 backdrop-blur-sm p-4"
-            >
-              <span className="text-2xl font-bold font-mono text-primary">
-                {stat.value}{stat.suffix}
-              </span>
-              <span className="text-xs text-muted-foreground text-center font-mono">
-                {stat.label}
-              </span>
-            </div>
-          ))}
-        </motion.div>
-
-        {/* Social links */}
-        <motion.div
-          className="flex gap-3"
-          variants={fadeInUp}
-          transition={DEFAULT_TRANSITION}
-        >
-          {SOCIAL_LINKS.map(({ label, href, icon: Icon }) => (
-            <Button
-              key={label}
-              variant="outline"
-              size="icon"
-              aria-label={label}
-              onClick={() => openLink(href)}
-              className="rounded-full w-10 h-10 border-border/60 hover:border-primary/60 hover:text-primary transition-colors"
-            >
-              <Icon className="w-4 h-4" />
-            </Button>
-          ))}
-        </motion.div>
-      </motion.div>
-    </div>
+    <>
+      <JsonLd data={breadcrumbSchema} />
+      <AboutContent />
+    </>
   );
 }

--- a/app/experience/page.tsx
+++ b/app/experience/page.tsx
@@ -1,11 +1,37 @@
+import type { Metadata } from "next";
 import ExperienceHeader from "@/components/experience/ExperienceHeader";
 import ExperienceTimeline from "@/components/experience/ExperienceTimeline";
+import JsonLd from "@/components/JsonLd";
+
+export const metadata: Metadata = {
+  title: "Experience",
+  description:
+    "3+ years of professional software engineering experience — from founding engineer roles to building products used by thousands.",
+  openGraph: {
+    title: "Experience — Raghul S",
+    description:
+      "3+ years of professional software engineering experience — from founding engineer roles to building products used by thousands.",
+    url: "https://raghuls.dev/experience",
+  },
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://raghuls.dev" },
+    { "@type": "ListItem", position: 2, name: "Experience", item: "https://raghuls.dev/experience" },
+  ],
+};
 
 export default function ExperiencePage() {
   return (
-    <div className="max-w-5xl mx-auto mt-8 px-4">
-      <ExperienceHeader />
-      <ExperienceTimeline />
-    </div>
+    <>
+      <JsonLd data={breadcrumbSchema} />
+      <div className="max-w-5xl mx-auto mt-8 px-4">
+        <ExperienceHeader />
+        <ExperienceTimeline />
+      </div>
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,8 +20,47 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Raghul S",
-  description: "A website to know me better",
+  metadataBase: new URL("https://raghuls.dev"),
+  title: {
+    default: "Raghul S | Founding Engineer @ Velt",
+    template: "%s | Raghul S",
+  },
+  description:
+    "Raghul S is a Founding Software Engineer at Velt, dedicated to innovation and transformation through the boundless possibilities of technology.",
+  authors: [{ name: "Raghul S", url: "https://raghuls.dev" }],
+  keywords: [
+    "Raghul S",
+    "software engineer",
+    "founding engineer",
+    "Velt",
+    "full stack",
+    "React",
+    "Next.js",
+    "TypeScript",
+    "portfolio",
+  ],
+  robots: { index: true, follow: true },
+  icons: {
+    icon: "/images/PortfolioLogo.png",
+    apple: "/images/PortfolioLogo.png",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://raghuls.dev",
+    siteName: "Raghul S",
+    title: "Raghul S | Founding Engineer @ Velt",
+    description:
+      "Raghul S is a Founding Software Engineer at Velt, dedicated to innovation and transformation through the boundless possibilities of technology.",
+    images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: "Raghul S — Founding Engineer @ Velt" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Raghul S | Founding Engineer @ Velt",
+    description:
+      "Raghul S is a Founding Software Engineer at Velt, dedicated to innovation and transformation through the boundless possibilities of technology.",
+    images: ["/opengraph-image"],
+  },
 };
 
 export default function RootLayout({
@@ -31,7 +70,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <link rel="icon" href={"/images/PortfolioLogo.png"} sizes="any" />
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
       >

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,105 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "Raghul S — Founding Engineer @ Velt";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#09090b",
+          fontFamily: "monospace",
+        }}
+      >
+        {/* Subtle grid pattern */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px)",
+            backgroundSize: "60px 60px",
+          }}
+        />
+
+        {/* Accent glow */}
+        <div
+          style={{
+            position: "absolute",
+            width: 600,
+            height: 300,
+            borderRadius: "50%",
+            background: "radial-gradient(ellipse, rgba(255,255,255,0.06) 0%, transparent 70%)",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        />
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 16,
+            zIndex: 1,
+          }}
+        >
+          <p
+            style={{
+              fontSize: 18,
+              color: "rgba(255,255,255,0.4)",
+              letterSpacing: "0.2em",
+              textTransform: "uppercase",
+              margin: 0,
+            }}
+          >
+            raghuls.dev
+          </p>
+
+          <h1
+            style={{
+              fontSize: 80,
+              fontWeight: 700,
+              color: "#ffffff",
+              margin: 0,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Raghul S
+          </h1>
+
+          <div
+            style={{
+              width: 80,
+              height: 3,
+              background: "linear-gradient(90deg, rgba(255,255,255,0.6), rgba(255,255,255,0.1))",
+              borderRadius: 9999,
+            }}
+          />
+
+          <p
+            style={{
+              fontSize: 28,
+              color: "rgba(255,255,255,0.6)",
+              margin: 0,
+              letterSpacing: "0.02em",
+            }}
+          >
+            Founding Engineer @ Velt
+          </p>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,45 @@
+import type { Metadata } from "next";
 import HeroSection from "@/components/landing/HeroSection";
 import StatsBar from "@/components/landing/StatsBar";
 import FeaturedWork from "@/components/landing/FeaturedWork";
 import QuickLinks from "@/components/landing/QuickLinks";
+import JsonLd from "@/components/JsonLd";
+
+export const metadata: Metadata = {
+  title: "Raghul S — Founding Engineer @ Velt",
+  description:
+    "Raghul S is a Founding Software Engineer at Velt, dedicated to innovation and transformation through the boundless possibilities of technology.",
+  openGraph: {
+    title: "Raghul S — Founding Engineer @ Velt",
+    description:
+      "Raghul S is a Founding Software Engineer at Velt, dedicated to innovation and transformation through the boundless possibilities of technology.",
+    url: "https://raghuls.dev",
+  },
+};
+
+const personSchema = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Raghul S",
+  jobTitle: "Founding Software Engineer",
+  worksFor: { "@type": "Organization", name: "Velt" },
+  url: "https://raghuls.dev",
+  sameAs: [
+    "https://www.linkedin.com/in/raghul-s25",
+    "https://www.github.com/itsraghul",
+  ],
+};
 
 export default function Home() {
   return (
-    <div className="w-full">
-      <HeroSection />
-      <StatsBar />
-      <FeaturedWork />
-      <QuickLinks />
-    </div>
+    <>
+      <JsonLd data={personSchema} />
+      <div className="w-full">
+        <HeroSection />
+        <StatsBar />
+        <FeaturedWork />
+        <QuickLinks />
+      </div>
+    </>
   );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,88 +1,33 @@
-"use client";
+import type { Metadata } from "next";
+import ProjectsContent from "@/components/projects/ProjectsContent";
+import JsonLd from "@/components/JsonLd";
 
-import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { PROJECTS } from "@/constants/projects";
-import ProjectCardModern from "@/components/ProjectCard/ProjectCardModern";
-import { staggerContainer, fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
+export const metadata: Metadata = {
+  title: "Projects",
+  description:
+    "8+ projects built across web, blockchain, tools, and games by Raghul S — Founding Engineer at Velt.",
+  openGraph: {
+    title: "Projects — Raghul S",
+    description:
+      "8+ projects built across web, blockchain, tools, and games by Raghul S — Founding Engineer at Velt.",
+    url: "https://raghuls.dev/projects",
+  },
+};
 
-const CATEGORIES = ["all", "web", "blockchain", "tools", "game"] as const;
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://raghuls.dev" },
+    { "@type": "ListItem", position: 2, name: "Projects", item: "https://raghuls.dev/projects" },
+  ],
+};
 
 export default function ProjectsPage() {
-  const [filter, setFilter] = useState("all");
-
-  const featured = PROJECTS.filter((p) => p.featured);
-  const filtered =
-    filter === "all"
-      ? PROJECTS.filter((p) => !p.featured)
-      : PROJECTS.filter((p) => p.category === filter && !p.featured);
-
   return (
-    <div className="max-w-6xl mx-auto w-full mt-8">
-      <motion.div
-        className="mb-10 text-center"
-        initial="hidden"
-        animate="visible"
-        variants={fadeInUp}
-        transition={DEFAULT_TRANSITION}
-      >
-        <h2 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
-          My Projects
-        </h2>
-        <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
-      </motion.div>
-
-      <motion.div
-        className="flex flex-wrap justify-center gap-2 mb-8"
-        initial="hidden"
-        animate="visible"
-        variants={fadeInUp}
-        transition={{ ...DEFAULT_TRANSITION, delay: 0.1 }}
-      >
-        {CATEGORIES.map((cat) => (
-          <button
-            key={cat}
-            onClick={() => setFilter(cat)}
-            className={`px-4 py-1.5 rounded-full text-xs font-mono font-semibold uppercase tracking-wider border transition-all duration-200 ${
-              filter === cat
-                ? "bg-primary text-primary-foreground border-primary"
-                : "bg-transparent text-muted-foreground border-border hover:border-primary/40 hover:text-primary"
-            }`}
-          >
-            {cat}
-          </button>
-        ))}
-      </motion.div>
-
-      {filter === "all" && featured.length > 0 && (
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8"
-          variants={staggerContainer}
-          initial="hidden"
-          animate="visible"
-        >
-          {featured.map((project) => (
-            <ProjectCardModern
-              key={project.name}
-              project={project}
-              className="min-h-[260px]"
-            />
-          ))}
-        </motion.div>
-      )}
-
-      <motion.div
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
-        variants={staggerContainer}
-        initial="hidden"
-        animate="visible"
-      >
-        <AnimatePresence mode="popLayout">
-          {filtered.map((project) => (
-            <ProjectCardModern key={project.name} project={project} />
-          ))}
-        </AnimatePresence>
-      </motion.div>
-    </div>
+    <>
+      <JsonLd data={breadcrumbSchema} />
+      <ProjectsContent />
+    </>
   );
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: "/others",
+      },
+    ],
+    sitemap: "https://raghuls.dev/sitemap.xml",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://raghuls.dev";
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/projects`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/experience`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/skills`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ];
+}

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -1,29 +1,33 @@
-"use client";
+import type { Metadata } from "next";
+import SkillsContent from "@/components/skills/SkillsContent";
+import JsonLd from "@/components/JsonLd";
 
-import { motion } from "framer-motion";
-import Skills3DWrapper from "@/components/skills/Skills3DWrapper";
-import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
+export const metadata: Metadata = {
+  title: "Skills",
+  description:
+    "Raghul S's technical skills across 12+ technologies — React, Next.js, TypeScript, Node.js, blockchain, and more.",
+  openGraph: {
+    title: "Skills — Raghul S",
+    description:
+      "Raghul S's technical skills across 12+ technologies — React, Next.js, TypeScript, Node.js, blockchain, and more.",
+    url: "https://raghuls.dev/skills",
+  },
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://raghuls.dev" },
+    { "@type": "ListItem", position: 2, name: "Skills", item: "https://raghuls.dev/skills" },
+  ],
+};
 
 export default function SkillsPage() {
   return (
-    <div className="w-screen h-[calc(100vh-4rem)] -mx-4 -mt-6 relative overflow-hidden">
-      <Skills3DWrapper />
-
-      <motion.div
-        className="absolute top-6 left-0 right-0 z-10 text-center pointer-events-none"
-        initial="hidden"
-        animate="visible"
-        variants={fadeInUp}
-        transition={DEFAULT_TRANSITION}
-      >
-        <h2 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
-          Skills
-        </h2>
-        <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
-        <p className="mt-2 text-sm text-muted-foreground font-mono">
-          Drag to orbit. Click a skill to inspect.
-        </p>
-      </motion.div>
-    </div>
+    <>
+      <JsonLd data={breadcrumbSchema} />
+      <SkillsContent />
+    </>
   );
 }

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+interface JsonLdProps {
+  data: object;
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/components/about/AboutContent.tsx
+++ b/components/about/AboutContent.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { GithubIcon, LinkedinIcon, Mail } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { openLink } from "@/lib/utils";
+import { HOMEPAGE_INFO, FEATURED_STATS } from "@/constants";
+import { fadeInUp, staggerContainer, scaleIn, DEFAULT_TRANSITION } from "@/lib/animations";
+import ProfilePortrait from "@/public/images/profile-portrait.png";
+
+const SOCIAL_LINKS = [
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/raghul-s25", icon: LinkedinIcon },
+  { label: "GitHub", href: "https://www.github.com/itsraghul", icon: GithubIcon },
+  { label: "Email", href: "mailto:raghul2521@gmail.com", icon: Mail },
+] as const;
+
+export default function AboutContent() {
+  return (
+    <div className="max-w-2xl mx-auto mt-12 px-4 pb-16">
+      <motion.div
+        className="flex flex-col items-center gap-8"
+        initial="hidden"
+        animate="visible"
+        variants={staggerContainer}
+      >
+        {/* Profile image */}
+        <motion.div
+          variants={scaleIn}
+          transition={DEFAULT_TRANSITION}
+          className="relative"
+        >
+          <div className="w-36 h-36 rounded-full ring-2 ring-border bg-secondary/30 overflow-hidden">
+            <Image
+              src={ProfilePortrait}
+              alt="Raghul S"
+              width={144}
+              height={144}
+              className="object-cover w-full h-full"
+              priority
+            />
+          </div>
+        </motion.div>
+
+        {/* Name & role */}
+        <motion.div
+          className="text-center"
+          variants={fadeInUp}
+          transition={DEFAULT_TRANSITION}
+        >
+          <h1 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
+            {HOMEPAGE_INFO.NAME_INFO}
+          </h1>
+          <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
+          <p className="mt-3 text-sm font-mono text-muted-foreground">
+            {HOMEPAGE_INFO.ROLE}
+          </p>
+        </motion.div>
+
+        {/* Bio */}
+        <motion.p
+          className="text-center text-muted-foreground leading-relaxed max-w-lg"
+          variants={fadeInUp}
+          transition={DEFAULT_TRANSITION}
+        >
+          {HOMEPAGE_INFO.BASIC_DESC}
+        </motion.p>
+
+        {/* Stats */}
+        <motion.div
+          className="grid grid-cols-3 gap-4 w-full"
+          variants={fadeInUp}
+          transition={DEFAULT_TRANSITION}
+        >
+          {FEATURED_STATS.map((stat) => (
+            <div
+              key={stat.label}
+              className="flex flex-col items-center gap-1 rounded-xl border border-border/50 bg-secondary/20 backdrop-blur-sm p-4"
+            >
+              <span className="text-2xl font-bold font-mono text-primary">
+                {stat.value}{stat.suffix}
+              </span>
+              <span className="text-xs text-muted-foreground text-center font-mono">
+                {stat.label}
+              </span>
+            </div>
+          ))}
+        </motion.div>
+
+        {/* Social links */}
+        <motion.div
+          className="flex gap-3"
+          variants={fadeInUp}
+          transition={DEFAULT_TRANSITION}
+        >
+          {SOCIAL_LINKS.map(({ label, href, icon: Icon }) => (
+            <Button
+              key={label}
+              variant="outline"
+              size="icon"
+              aria-label={label}
+              onClick={() => openLink(href)}
+              className="rounded-full w-10 h-10 border-border/60 hover:border-primary/60 hover:text-primary transition-colors"
+            >
+              <Icon className="w-4 h-4" />
+            </Button>
+          ))}
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/components/projects/ProjectsContent.tsx
+++ b/components/projects/ProjectsContent.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { PROJECTS } from "@/constants/projects";
+import ProjectCardModern from "@/components/ProjectCard/ProjectCardModern";
+import { staggerContainer, fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
+
+const CATEGORIES = ["all", "web", "blockchain", "tools", "game"] as const;
+
+export default function ProjectsContent() {
+  const [filter, setFilter] = useState("all");
+
+  const featured = PROJECTS.filter((p) => p.featured);
+  const filtered =
+    filter === "all"
+      ? PROJECTS.filter((p) => !p.featured)
+      : PROJECTS.filter((p) => p.category === filter && !p.featured);
+
+  return (
+    <div className="max-w-6xl mx-auto w-full mt-8">
+      <motion.div
+        className="mb-10 text-center"
+        initial="hidden"
+        animate="visible"
+        variants={fadeInUp}
+        transition={DEFAULT_TRANSITION}
+      >
+        <h2 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
+          My Projects
+        </h2>
+        <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
+      </motion.div>
+
+      <motion.div
+        className="flex flex-wrap justify-center gap-2 mb-8"
+        initial="hidden"
+        animate="visible"
+        variants={fadeInUp}
+        transition={{ ...DEFAULT_TRANSITION, delay: 0.1 }}
+      >
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setFilter(cat)}
+            className={`px-4 py-1.5 rounded-full text-xs font-mono font-semibold uppercase tracking-wider border transition-all duration-200 ${
+              filter === cat
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-transparent text-muted-foreground border-border hover:border-primary/40 hover:text-primary"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </motion.div>
+
+      {filter === "all" && featured.length > 0 && (
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8"
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+        >
+          {featured.map((project) => (
+            <ProjectCardModern
+              key={project.name}
+              project={project}
+              className="min-h-[260px]"
+            />
+          ))}
+        </motion.div>
+      )}
+
+      <motion.div
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+      >
+        <AnimatePresence mode="popLayout">
+          {filtered.map((project) => (
+            <ProjectCardModern key={project.name} project={project} />
+          ))}
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  );
+}

--- a/components/skills/SkillsContent.tsx
+++ b/components/skills/SkillsContent.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Skills3DWrapper from "@/components/skills/Skills3DWrapper";
+import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
+
+export default function SkillsContent() {
+  return (
+    <div className="w-screen h-[calc(100vh-4rem)] -mx-4 -mt-6 relative overflow-hidden">
+      <Skills3DWrapper />
+
+      <motion.div
+        className="absolute top-6 left-0 right-0 z-10 text-center pointer-events-none"
+        initial="hidden"
+        animate="visible"
+        variants={fadeInUp}
+        transition={DEFAULT_TRANSITION}
+      >
+        <h2 className="text-3xl sm:text-4xl font-bold font-mono text-primary">
+          Skills
+        </h2>
+        <div className="mt-3 mx-auto w-20 h-1 rounded-full bg-gradient-to-r from-primary/60 to-primary/20" />
+        <p className="mt-2 text-sm text-muted-foreground font-mono">
+          Drag to orbit. Click a skill to inspect.
+        </p>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Upgraded root metadata in `app/layout.tsx` with a title template, full Open Graph and Twitter card config, author/keywords/robots directives, and proper icon setup via the Next.js metadata API
- Added unique `title`, `description`, and `openGraph` exports to every public page (`/`, `/about`, `/projects`, `/experience`, `/skills`)
- Created `app/robots.ts` (disallows `/others`), `app/sitemap.ts` (all 5 public routes), and `app/opengraph-image.tsx` (edge-rendered 1200×630 OG image)
- Added `components/JsonLd.tsx` server component helper; homepage gets a `Person` schema and all inner pages get a `BreadcrumbList` schema
- Extracted client-side logic from `about/page.tsx`, `projects/page.tsx`, and `skills/page.tsx` into `components/about/AboutContent.tsx`, `components/projects/ProjectsContent.tsx`, and `components/skills/SkillsContent.tsx` so page files can export `metadata` as server components

🤖 Generated with [Claude Code](https://claude.com/claude-code)