### PR TITLE
Add interactive portfolio innovations: terminal, cursor, 3D intro & UX polish

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { GithubIcon, LinkedinIcon, Mail } from "lucide-react";
@@ -8,6 +9,7 @@ import { openLink } from "@/lib/utils";
 import { HOMEPAGE_INFO, FEATURED_STATS } from "@/constants";
 import { fadeInUp, staggerContainer, scaleIn, DEFAULT_TRANSITION } from "@/lib/animations";
 import ProfilePortrait from "@/public/images/profile-portrait.png";
+import ReadingProgress from "@/components/ui/ReadingProgress";
 
 const SOCIAL_LINKS = [
   { label: "LinkedIn", href: "https://www.linkedin.com/in/raghul-s25", icon: LinkedinIcon },
@@ -16,8 +18,11 @@ const SOCIAL_LINKS = [
 ] as const;
 
 export default function AboutPage() {
+  const contentRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="max-w-2xl mx-auto mt-12 px-4 pb-16">
+    <div ref={contentRef} className="max-w-2xl mx-auto mt-12 px-4 pb-16">
+      <ReadingProgress containerRef={contentRef} />
       <motion.div
         className="flex flex-col items-center gap-8"
         initial="hidden"

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,4 +99,10 @@ body {
   }
 }
 
+/* Custom cursor — hide default on fine-pointer devices */
+.cursor-none-global,
+.cursor-none-global * {
+  cursor: none !important;
+}
+
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import NavBar from "@/components/NavBar/NavBar";
 import Footer from "@/components/Footer/Footer";
 import ScrollProgress from "@/components/ui/ScrollProgress";
 import AppProvider from "@/components/providers/AppProvider";
+import BuildingBanner from "@/components/Banner/BuildingBanner";
+import CustomCursor from "@/components/Cursor/CustomCursor";
 import { SpeedInsights } from '@vercel/speed-insights/next';
 
 
@@ -37,7 +39,9 @@ export default function RootLayout({
       >
         <AppProvider>
           <>
+            <CustomCursor />
             <ScrollProgress />
+            <BuildingBanner />
             <NavBar />
             <main className="flex-grow mx-auto px-4 py-6 mt-16 flex w-full">
               {children}

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -2,12 +2,14 @@
 
 import { motion } from "framer-motion";
 import Skills3DWrapper from "@/components/skills/Skills3DWrapper";
+import SoundToggle from "@/components/skills/SoundToggle";
 import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
 
 export default function SkillsPage() {
   return (
     <div className="w-screen h-[calc(100vh-4rem)] -mx-4 -mt-6 relative overflow-hidden">
       <Skills3DWrapper />
+      <SoundToggle />
 
       <motion.div
         className="absolute top-6 left-0 right-0 z-10 text-center pointer-events-none"

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
+
+const Terminal = dynamic(() => import("@/components/Terminal/Terminal"), { ssr: false });
+
+export default function TerminalPage() {
+  return (
+    <div className="fixed inset-0 bg-[#050505] flex flex-col z-50">
+      {/* Back link */}
+      <div className="shrink-0 px-4 pt-3 pb-2">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 text-xs font-mono text-white/30 hover:text-white/60 transition-colors"
+        >
+          <ArrowLeftIcon className="w-3 h-3" />
+          back to portfolio
+        </Link>
+      </div>
+
+      {/* Terminal fills remaining space */}
+      <div className="flex-1 px-4 pb-4 min-h-0">
+        <Terminal />
+      </div>
+    </div>
+  );
+}

--- a/components/Banner/BuildingBanner.tsx
+++ b/components/Banner/BuildingBanner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { XIcon, ExternalLinkIcon } from "lucide-react";
+import { CURRENTLY_BUILDING } from "@/constants";
+
+const DISMISS_KEY = "building-banner-dismissed";
+
+export default function BuildingBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const dismissed = localStorage.getItem(DISMISS_KEY);
+    if (!dismissed) setVisible(true);
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+    setVisible(false);
+  };
+
+  if (!CURRENTLY_BUILDING.active) return null;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ y: -40, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -40, opacity: 0 }}
+          transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          className="relative z-50 flex items-center justify-center gap-2 bg-primary/8 border-b border-primary/15 px-4 py-2 text-xs font-mono text-muted-foreground"
+        >
+          {/* Live dot */}
+          <span className="relative flex h-2 w-2 shrink-0">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+          </span>
+
+          <span className="text-center leading-tight">
+            {CURRENTLY_BUILDING.text}
+          </span>
+
+          <a
+            href={CURRENTLY_BUILDING.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-primary/70 hover:text-primary transition-colors shrink-0"
+          >
+            <ExternalLinkIcon className="w-3 h-3" />
+          </a>
+
+          <button
+            onClick={dismiss}
+            aria-label="Dismiss banner"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+          >
+            <XIcon className="w-3.5 h-3.5" />
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/Cursor/CustomCursor.tsx
+++ b/components/Cursor/CustomCursor.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { motion, useMotionValue, useSpring } from "framer-motion";
+
+export default function CustomCursor() {
+  const [visible, setVisible] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const cursorX = useMotionValue(-100);
+  const cursorY = useMotionValue(-100);
+
+  // Ring lags behind dot for a trailing effect
+  const springX = useSpring(cursorX, { stiffness: 350, damping: 30 });
+  const springY = useSpring(cursorY, { stiffness: 350, damping: 30 });
+
+  const isFinePointer = useRef(false);
+
+  useEffect(() => {
+    // Only activate on non-touch devices
+    isFinePointer.current = window.matchMedia("(pointer: fine)").matches;
+    if (!isFinePointer.current) return;
+
+    const onMove = (e: MouseEvent) => {
+      cursorX.set(e.clientX);
+      cursorY.set(e.clientY);
+      if (!visible) setVisible(true);
+    };
+
+    const onEnter = () => {
+      const el = document.querySelector(":hover");
+      if (el instanceof HTMLElement) {
+        const tag = el.tagName.toLowerCase();
+        const isCursorable = tag === "a" || tag === "button" || el.dataset.cursor === "hover" ||
+          el.closest("a") !== null || el.closest("button") !== null;
+        setHovered(isCursorable);
+      }
+    };
+
+    const onLeave = () => {
+      setVisible(false);
+      setHovered(false);
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseover", onEnter);
+    document.addEventListener("mouseleave", onLeave);
+
+    // Hide default cursor
+    document.documentElement.classList.add("cursor-none-global");
+
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseover", onEnter);
+      document.removeEventListener("mouseleave", onLeave);
+      document.documentElement.classList.remove("cursor-none-global");
+    };
+  }, [cursorX, cursorY, visible]);
+
+  if (!visible) return null;
+
+  return (
+    <>
+      {/* Outer ring — lags behind */}
+      <motion.div
+        className="pointer-events-none fixed top-0 left-0 z-[9999] rounded-full border border-primary/40 mix-blend-difference"
+        style={{
+          x: springX,
+          y: springY,
+          translateX: "-50%",
+          translateY: "-50%",
+          width: hovered ? 40 : 28,
+          height: hovered ? 40 : 28,
+          transition: "width 0.2s ease, height 0.2s ease",
+        }}
+      />
+      {/* Inner dot — instant */}
+      <motion.div
+        className="pointer-events-none fixed top-0 left-0 z-[9999] rounded-full bg-primary/80"
+        style={{
+          x: cursorX,
+          y: cursorY,
+          translateX: "-50%",
+          translateY: "-50%",
+          width: hovered ? 6 : 4,
+          height: hovered ? 6 : 4,
+          transition: "width 0.15s ease, height 0.15s ease",
+        }}
+      />
+    </>
+  );
+}

--- a/components/Cursor/MagneticWrapper.tsx
+++ b/components/Cursor/MagneticWrapper.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRef, ReactNode } from "react";
+import { motion, useMotionValue, useSpring } from "framer-motion";
+
+interface MagneticWrapperProps {
+  children: ReactNode;
+  strength?: number;
+  className?: string;
+}
+
+export default function MagneticWrapper({
+  children,
+  strength = 0.35,
+  className,
+}: MagneticWrapperProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const springX = useSpring(x, { stiffness: 200, damping: 20 });
+  const springY = useSpring(y, { stiffness: 200, damping: 20 });
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    x.set((e.clientX - cx) * strength);
+    y.set((e.clientY - cy) * strength);
+  };
+
+  const handleMouseLeave = () => {
+    x.set(0);
+    y.set(0);
+  };
+
+  return (
+    <motion.div
+      ref={ref}
+      style={{ x: springX, y: springY }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      className={className}
+      data-cursor="hover"
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Button } from '../ui/button';
 import { GithubIcon, LinkedinIcon, Mail } from 'lucide-react';
 import { openLink } from '@/lib/utils';
+import MagneticWrapper from '../Cursor/MagneticWrapper';
 
 type contactLink = {
     link: string
@@ -30,9 +31,11 @@ const Footer = () => {
             <>
                 {
                     contactLinks.map((contact, index) => (
-                        <Button variant={'ghost'} key={index} onClick={() => openLink(contact.link)}>
-                            {contact.icon}
-                        </Button>
+                        <MagneticWrapper key={index} strength={0.5}>
+                            <Button variant={'ghost'} onClick={() => openLink(contact.link)}>
+                                {contact.icon}
+                            </Button>
+                        </MagneticWrapper>
                     ))
                 }
             </>

--- a/components/NavBar/NavBar.tsx
+++ b/components/NavBar/NavBar.tsx
@@ -9,6 +9,8 @@ import { MenuIcon, XIcon } from "lucide-react";
 import LogoLight from "../../public/images/PortfolioLogo-transparent.png";
 import LogoDark from "../../public/images/PortfolioLogoDark-transparent.png";
 import ThemeToggle from "../ThemeToggle/ThemeToggle";
+import MagneticWrapper from "../Cursor/MagneticWrapper";
+import { TerminalIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const PAGE_LINKS = ["experience", "projects", "skills", "about"] as const;
@@ -30,19 +32,37 @@ export default function NavBar() {
         <ul className="hidden sm:flex flex-row gap-6 items-center">
           {PAGE_LINKS.map((link) => (
             <li key={link}>
+              <MagneticWrapper strength={0.4}>
+                <Link
+                  href={`/${link}`}
+                  className={cn(
+                    "font-mono text-sm capitalize transition-colors hover:text-primary",
+                    pathname === `/${link}`
+                      ? "text-primary font-semibold"
+                      : "text-muted-foreground"
+                  )}
+                >
+                  {link}
+                </Link>
+              </MagneticWrapper>
+            </li>
+          ))}
+          <li>
+            <MagneticWrapper strength={0.4}>
               <Link
-                href={`/${link}`}
+                href="/terminal"
+                title="Open terminal"
                 className={cn(
-                  "font-mono text-sm capitalize transition-colors hover:text-primary",
-                  pathname === `/${link}`
-                    ? "text-primary font-semibold"
+                  "flex items-center justify-center w-8 h-8 rounded-md transition-colors hover:text-primary hover:bg-secondary/50",
+                  pathname === "/terminal"
+                    ? "text-primary bg-secondary/50"
                     : "text-muted-foreground"
                 )}
               >
-                {link}
+                <TerminalIcon className="w-4 h-4" />
               </Link>
-            </li>
-          ))}
+            </MagneticWrapper>
+          </li>
           <li>
             <ThemeToggle />
           </li>
@@ -80,6 +100,21 @@ export default function NavBar() {
                 </Link>
               </li>
             ))}
+            <li>
+              <Link
+                href="/terminal"
+                onClick={() => setMobileOpen(false)}
+                className={cn(
+                  "flex items-center gap-2 py-2 px-3 rounded-lg font-mono text-sm transition-colors",
+                  pathname === "/terminal"
+                    ? "text-primary bg-secondary/50 font-semibold"
+                    : "text-muted-foreground hover:text-primary hover:bg-secondary/30"
+                )}
+              >
+                <TerminalIcon className="w-4 h-4" />
+                terminal
+              </Link>
+            </li>
           </ul>
         </div>
       )}

--- a/components/ProjectCard/ProjectCardModern.tsx
+++ b/components/ProjectCard/ProjectCardModern.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { Code2Icon, EarthIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { openLink } from "@/lib/utils";
 import { fadeInUp, DEFAULT_TRANSITION } from "@/lib/animations";
 import type { Project } from "@/types";
@@ -20,7 +21,7 @@ interface ProjectCardModernProps {
 }
 
 export default function ProjectCardModern({ project, className = "" }: ProjectCardModernProps) {
-  const { name, stack, description, githubLink, websiteLink, category } = project;
+  const { name, stack, description, githubLink, websiteLink, category, techDescriptions } = project;
   const accentColor = CATEGORY_COLORS[category ?? "web"] ?? "#3b82f6";
   const techPills = stack.split("|").map((t) => t.trim()).filter(Boolean);
 
@@ -55,16 +56,30 @@ export default function ProjectCardModern({ project, className = "" }: ProjectCa
           )}
         </div>
 
-        <div className="flex flex-wrap gap-1.5">
-          {techPills.map((tech) => (
-            <span
-              key={tech}
-              className="text-[11px] font-mono px-2 py-0.5 rounded-md bg-muted text-muted-foreground"
-            >
-              {tech}
-            </span>
-          ))}
-        </div>
+        <TooltipProvider delayDuration={200}>
+          <div className="flex flex-wrap gap-1.5">
+            {techPills.map((tech) => {
+              const desc = techDescriptions?.[tech];
+              const pill = (
+                <span
+                  key={tech}
+                  className="text-[11px] font-mono px-2 py-0.5 rounded-md bg-muted text-muted-foreground"
+                >
+                  {tech}
+                </span>
+              );
+              if (!desc) return pill;
+              return (
+                <Tooltip key={tech}>
+                  <TooltipTrigger asChild>{pill}</TooltipTrigger>
+                  <TooltipContent side="top" className="font-mono text-[11px]">
+                    {tech} → {desc}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        </TooltipProvider>
 
         <p className="text-sm text-muted-foreground leading-relaxed line-clamp-3 flex-1">
           {description}

--- a/components/Terminal/Terminal.tsx
+++ b/components/Terminal/Terminal.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback, KeyboardEvent } from "react";
+import { openLink } from "@/lib/utils";
+import { HOMEPAGE_INFO } from "@/constants";
+import { PROJECTS } from "@/constants/projects";
+import { experience } from "@/constants/experience";
+
+interface OutputLine {
+  type: "input" | "output" | "error" | "success" | "ascii";
+  content: string;
+}
+
+const PROMPT = "raghul@portfolio:~$";
+
+const ASCII_ART = `
+██████╗  █████╗  ██████╗ ██╗  ██╗██╗   ██╗██╗
+██╔══██╗██╔══██╗██╔════╝ ██║  ██║██║   ██║██║
+██████╔╝███████║██║  ███╗███████║██║   ██║██║
+██╔══██╗██╔══██║██║   ██║██╔══██║██║   ██║██║
+██║  ██║██║  ██║╚██████╔╝██║  ██║╚██████╔╝███████╗
+╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝ ╚═════╝ ╚══════╝
+`.trim();
+
+const NEOFETCH_OUTPUT = [
+  `                    ${HOMEPAGE_INFO.NAME_INFO}`,
+  `                    ─────────────────────────`,
+  `  ██████████        OS: Next.js 14 (App Router)`,
+  `  ██████████        Shell: zsh + TypeScript`,
+  `  ██████████        DE: React + Framer Motion`,
+  `  ██████████        WM: TailwindCSS`,
+  `  ██████████        Theme: Dark (default)`,
+  `  ██████████        Resolution: 1920x1080`,
+  `                    Uptime: 3+ years of shipping`,
+  `                    CPU: Problem Solving @ 100%`,
+  `                    RAM: Curiosity (unlimited)`,
+].join("\n");
+
+function processCommand(raw: string): OutputLine[] {
+  const trimmed = raw.trim();
+  const [cmd, ...args] = trimmed.split(/\s+/);
+  const arg = args.join(" ");
+
+  if (!trimmed) return [];
+
+  switch (cmd.toLowerCase()) {
+    case "help":
+      return [{
+        type: "output",
+        content: [
+          "Available commands:",
+          "  help              — show this list",
+          "  whoami            — about me",
+          "  ls                — list directories",
+          "  ls projects/      — list all projects",
+          "  ls skills/        — list tech skills",
+          "  cat experience    — work history",
+          "  open <project>    — open a project link",
+          "  neofetch          — system info",
+          "  clear             — clear terminal",
+          "  exit              — return to portfolio",
+        ].join("\n"),
+      }];
+
+    case "whoami":
+      return [{
+        type: "output",
+        content: [
+          `Name:   ${HOMEPAGE_INFO.NAME_INFO.replace("I'm ", "")}`,
+          `Role:   ${HOMEPAGE_INFO.ROLE}`,
+          `Bio:    ${HOMEPAGE_INFO.BASIC_DESC}`,
+        ].join("\n"),
+      }];
+
+    case "ls": {
+      if (!arg || arg === "./") {
+        return [{
+          type: "output",
+          content: "\x1b[34mprojects/\x1b[0m  \x1b[34mexperience/\x1b[0m  \x1b[34mskills/\x1b[0m  README.md",
+        }];
+      }
+      if (arg === "projects/" || arg === "projects") {
+        const list = PROJECTS.map((p, i) =>
+          `  [${String(i + 1).padStart(2, "0")}] ${p.name.split(" - ")[0]}  (${p.category})`
+        ).join("\n");
+        return [{ type: "output", content: `Projects:\n${list}` }];
+      }
+      if (arg === "skills/" || arg === "skills") {
+        return [{
+          type: "output",
+          content: "Skills:\n  TypeScript  React  Next.js  Node.js  Docker  Kubernetes  GCP  Redis  Java  Angular  RxJS  Playwright  JUnit  HTML  CSS",
+        }];
+      }
+      return [{ type: "error", content: `ls: cannot access '${arg}': No such file or directory` }];
+    }
+
+    case "cat": {
+      if (arg === "experience" || arg === "experience.json" || arg === "experience/") {
+        const output = experience.map((e) =>
+          [
+            `┌─ ${e.company} — ${e.role}`,
+            `│  ${e.date}`,
+            e.description.slice(0, 2).map((d) => `│  • ${d}`).join("\n"),
+            "└─",
+          ].join("\n")
+        ).join("\n\n");
+        return [{ type: "output", content: output }];
+      }
+      if (arg === "README.md") {
+        return [{
+          type: "output",
+          content: `# ${HOMEPAGE_INFO.NAME_INFO.replace("I'm ", "")}\n\n${HOMEPAGE_INFO.BASIC_DESC}\n\nRun 'help' to see what you can do here.`,
+        }];
+      }
+      return [{ type: "error", content: `cat: ${arg}: No such file or directory` }];
+    }
+
+    case "open": {
+      if (!arg) return [{ type: "error", content: "Usage: open <project-name>" }];
+      const match = PROJECTS.find(
+        (p) => p.name.toLowerCase().includes(arg.toLowerCase())
+      );
+      if (!match) {
+        return [{ type: "error", content: `open: no project matching '${arg}'. Try 'ls projects/' first.` }];
+      }
+      const url = match.websiteLink || match.githubLink;
+      if (!url) {
+        return [{ type: "error", content: `'${match.name.split(" - ")[0]}' has no public link.` }];
+      }
+      openLink(url);
+      return [{ type: "success", content: `Opening ${match.name.split(" - ")[0]}…` }];
+    }
+
+    case "neofetch":
+      return [{ type: "ascii", content: NEOFETCH_OUTPUT }];
+
+    case "clear":
+      return [{ type: "output", content: "__CLEAR__" }];
+
+    case "exit":
+      if (typeof window !== "undefined") window.history.back();
+      return [{ type: "output", content: "Returning to portfolio…" }];
+
+    case "cd":
+      return [{ type: "output", content: "" }];
+
+    default:
+      return [{ type: "error", content: `command not found: ${cmd}. Type 'help' for available commands.` }];
+  }
+}
+
+export default function Terminal() {
+  const [history, setHistory] = useState<OutputLine[]>([
+    {
+      type: "ascii",
+      content: ASCII_ART,
+    },
+    {
+      type: "output",
+      content: `Welcome! Type 'help' to see available commands.\n`,
+    },
+  ]);
+  const [input, setInput] = useState("");
+  const [cmdHistory, setCmdHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [history]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const runCommand = useCallback((raw: string) => {
+    const results = processCommand(raw);
+
+    if (results.length === 1 && results[0].content === "__CLEAR__") {
+      setHistory([]);
+      return;
+    }
+
+    setHistory((prev) => [
+      ...prev,
+      { type: "input", content: raw },
+      ...results,
+    ]);
+    if (raw.trim()) {
+      setCmdHistory((prev) => [raw, ...prev]);
+    }
+  }, []);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      runCommand(input);
+      setInput("");
+      setHistoryIndex(-1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const next = Math.min(historyIndex + 1, cmdHistory.length - 1);
+      setHistoryIndex(next);
+      setInput(cmdHistory[next] ?? "");
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = Math.max(historyIndex - 1, -1);
+      setHistoryIndex(next);
+      setInput(next === -1 ? "" : cmdHistory[next] ?? "");
+    }
+  }, [input, runCommand, historyIndex, cmdHistory]);
+
+  return (
+    <div
+      className="w-full h-full bg-[#0a0a0a] text-[#e2e8f0] font-mono text-sm flex flex-col rounded-xl overflow-hidden border border-white/10"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {/* Title bar */}
+      <div className="flex items-center gap-2 px-4 py-3 bg-[#111] border-b border-white/10 shrink-0">
+        <span className="w-3 h-3 rounded-full bg-[#ff5f57]" />
+        <span className="w-3 h-3 rounded-full bg-[#febc2e]" />
+        <span className="w-3 h-3 rounded-full bg-[#28c840]" />
+        <span className="ml-auto text-xs text-white/30">raghul@portfolio — terminal</span>
+      </div>
+
+      {/* Output */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-1 scrollbar-thin scrollbar-thumb-white/10">
+        {history.map((line, i) => (
+          <div key={i}>
+            {line.type === "input" && (
+              <div className="flex gap-2">
+                <span className="text-emerald-400 shrink-0">{PROMPT}</span>
+                <span className="text-white/90">{line.content}</span>
+              </div>
+            )}
+            {line.type === "output" && (
+              <pre className="text-[#94a3b8] whitespace-pre-wrap break-words leading-relaxed pl-2">
+                {line.content}
+              </pre>
+            )}
+            {line.type === "success" && (
+              <pre className="text-emerald-400 whitespace-pre-wrap pl-2">{line.content}</pre>
+            )}
+            {line.type === "error" && (
+              <pre className="text-red-400 whitespace-pre-wrap pl-2">{line.content}</pre>
+            )}
+            {line.type === "ascii" && (
+              <pre className="text-emerald-400/80 whitespace-pre text-[10px] sm:text-xs leading-tight overflow-x-auto">
+                {line.content}
+              </pre>
+            )}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="flex items-center gap-2 px-4 py-3 border-t border-white/10 shrink-0 bg-[#0d0d0d]">
+        <span className="text-emerald-400 shrink-0">{PROMPT}</span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="flex-1 bg-transparent outline-none text-white/90 caret-emerald-400 placeholder:text-white/20"
+          placeholder="type a command…"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="animate-cursor-blink text-emerald-400 font-bold">█</span>
+      </div>
+    </div>
+  );
+}

--- a/components/skills/SkillsScene.tsx
+++ b/components/skills/SkillsScene.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback, useMemo, Suspense } from "react";
-import { Canvas } from "@react-three/fiber";
+import { useState, useCallback, useMemo, useRef, useEffect, Suspense } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, Stars, Line } from "@react-three/drei";
 import { useTheme } from "next-themes";
 import * as THREE from "three";
@@ -10,6 +10,37 @@ import SkillCard3D from "./SkillCard3D";
 import SkillDetailPanel from "./SkillDetailPanel";
 import Earth from "./Earth";
 import type { Card } from "@/types";
+
+const INTRO_PLAYED_KEY = "skills-intro-played";
+const TARGET_POSITION = new THREE.Vector3(0, 3, 14);
+const START_POSITION = new THREE.Vector3(0, 18, 38);
+
+function CameraIntro({ onComplete }: { onComplete: () => void }) {
+  const { camera } = useThree();
+  const progress = useRef(0);
+  const done = useRef(false);
+
+  useEffect(() => {
+    camera.position.copy(START_POSITION);
+    camera.lookAt(0, 0, 0);
+  }, [camera]);
+
+  useFrame((_, delta) => {
+    if (done.current) return;
+    progress.current = Math.min(progress.current + delta / 2.8, 1);
+    // Smoothstep easing for cinematic feel
+    const t = progress.current * progress.current * (3 - 2 * progress.current);
+    camera.position.lerpVectors(START_POSITION, TARGET_POSITION, t);
+    camera.lookAt(0, 0, 0);
+    if (progress.current >= 1) {
+      done.current = true;
+      sessionStorage.setItem(INTRO_PLAYED_KEY, "1");
+      onComplete();
+    }
+  });
+
+  return null;
+}
 
 interface OrbitConfig {
   radius: number;
@@ -63,6 +94,10 @@ export default function SkillsScene() {
   const [selected, setSelected] = useState<Card | null>(null);
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
+  const [introComplete, setIntroComplete] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return sessionStorage.getItem(INTRO_PLAYED_KEY) === "1";
+  });
 
   const orbitConfigs = useMemo(
     () => generateOrbitConfigs(skills.length),
@@ -78,7 +113,7 @@ export default function SkillsScene() {
   return (
     <div className="relative w-full h-full rounded-xl overflow-hidden">
       <Canvas
-        camera={{ position: [0, 3, 14], fov: 45 }}
+        camera={{ position: introComplete ? [0, 3, 14] : [0, 18, 38], fov: 45 }}
         style={{
           background: isDark
             ? "radial-gradient(ellipse at center, #0f172a 0%, #020617 70%, #000000 100%)"
@@ -86,6 +121,7 @@ export default function SkillsScene() {
         }}
       >
         <Suspense fallback={null}>
+        {!introComplete && <CameraIntro onComplete={() => setIntroComplete(true)} />}
         <ambientLight intensity={isDark ? 0.4 : 0.6} />
         <directionalLight position={[10, 5, 10]} intensity={isDark ? 0.8 : 1.0} />
         {isDark && (
@@ -131,6 +167,7 @@ export default function SkillsScene() {
         })}
 
         <OrbitControls
+          enabled={introComplete}
           enableZoom={false}
           enablePan={false}
           autoRotate

--- a/components/skills/SoundToggle.tsx
+++ b/components/skills/SoundToggle.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { Volume2Icon, VolumeXIcon } from "lucide-react";
+
+// Place a royalty-free ambient audio file at /public/audio/space-ambient.mp3
+// Suggested source: https://freesound.org (CC0 license)
+const AUDIO_SRC = "/audio/space-ambient.mp3";
+
+export default function SoundToggle() {
+  const [playing, setPlaying] = useState(false);
+  const [supported, setSupported] = useState(true);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const gainRef = useRef<GainNode | null>(null);
+  const ctxRef = useRef<AudioContext | null>(null);
+  const sourceRef = useRef<MediaElementAudioSourceNode | null>(null);
+
+  const initAudio = useCallback(() => {
+    if (audioRef.current) return; // already created
+
+    try {
+      const audio = new Audio(AUDIO_SRC);
+      audio.loop = true;
+      audio.volume = 0;
+      audioRef.current = audio;
+
+      const ctx = new AudioContext();
+      ctxRef.current = ctx;
+
+      const source = ctx.createMediaElementSource(audio);
+      sourceRef.current = source;
+
+      const gain = ctx.createGain();
+      gain.gain.value = 0;
+      gainRef.current = gain;
+
+      source.connect(gain);
+      gain.connect(ctx.destination);
+    } catch {
+      setSupported(false);
+    }
+  }, []);
+
+  const toggle = useCallback(async () => {
+    initAudio();
+    if (!audioRef.current || !gainRef.current || !ctxRef.current) return;
+
+    if (!playing) {
+      if (ctxRef.current.state === "suspended") {
+        await ctxRef.current.resume();
+      }
+      audioRef.current.play().catch(() => setSupported(false));
+      gainRef.current.gain.cancelScheduledValues(ctxRef.current.currentTime);
+      gainRef.current.gain.setValueAtTime(0, ctxRef.current.currentTime);
+      gainRef.current.gain.linearRampToValueAtTime(0.28, ctxRef.current.currentTime + 1.5);
+      setPlaying(true);
+    } else {
+      const now = ctxRef.current.currentTime;
+      gainRef.current.gain.cancelScheduledValues(now);
+      gainRef.current.gain.setValueAtTime(gainRef.current.gain.value, now);
+      gainRef.current.gain.linearRampToValueAtTime(0, now + 0.8);
+      setTimeout(() => {
+        audioRef.current?.pause();
+      }, 850);
+      setPlaying(false);
+    }
+  }, [playing, initAudio]);
+
+  if (!supported) return null;
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={playing ? "Mute ambient sound" : "Play ambient sound"}
+      title={playing ? "Mute" : "Ambient sound"}
+      className="absolute bottom-4 left-4 z-20 flex items-center justify-center w-9 h-9 rounded-full bg-black/30 backdrop-blur-sm border border-white/10 text-white/50 hover:text-white/80 hover:bg-black/50 transition-all duration-200"
+    >
+      {playing ? (
+        <Volume2Icon className="w-4 h-4" />
+      ) : (
+        <VolumeXIcon className="w-4 h-4" />
+      )}
+    </button>
+  );
+}

--- a/components/ui/ReadingProgress.tsx
+++ b/components/ui/ReadingProgress.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { RefObject } from "react";
+import { motion, useScroll, useSpring } from "framer-motion";
+
+interface ReadingProgressProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+}
+
+export default function ReadingProgress({ containerRef }: ReadingProgressProps) {
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ["start 0.8", "end end"],
+  });
+
+  const scaleY = useSpring(scrollYProgress, { stiffness: 200, damping: 30 });
+
+  return (
+    <motion.div
+      className="fixed right-5 top-1/2 -translate-y-1/2 hidden md:flex flex-col items-center gap-2 z-40 pointer-events-none"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 0.6, duration: 0.5 }}
+    >
+      <div className="relative w-[2px] h-32 bg-border/40 rounded-full overflow-hidden">
+        <motion.div
+          className="absolute top-0 left-0 w-full bg-primary/50 rounded-full origin-top"
+          style={{ scaleY, height: "100%" }}
+        />
+      </div>
+      <span className="text-[9px] font-mono text-muted-foreground/30 tracking-widest [writing-mode:vertical-rl] select-none">
+        READ
+      </span>
+    </motion.div>
+  );
+}

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -14,3 +14,9 @@ export const FEATURED_STATS = [
     { value: 8, suffix: "+", label: "Projects Built" },
     { value: 12, suffix: "+", label: "Technologies" },
 ] as const;
+
+export const CURRENTLY_BUILDING = {
+    text: "Currently building real-time collaboration & AI-powered workflow automation at Velt",
+    link: "https://velt.dev",
+    active: true,
+} as const;

--- a/constants/projects/index.ts
+++ b/constants/projects/index.ts
@@ -9,6 +9,11 @@ export const PROJECTS: Project[] = [
         websiteLink: "https://www.mock-data.com",
         category: "web",
         featured: true,
+        techDescriptions: {
+            "Next.js": "App router, API routes & SSR",
+            "Faker.js": "200+ data types across 43 locales",
+            "TailwindCSS": "UI layout & responsive design",
+        },
     },
     {
         name: "DataForge - Through WebScrape workflow",
@@ -18,6 +23,12 @@ export const PROJECTS: Project[] = [
         websiteLink: "https://flow-data-forge.vercel.app/",
         category: "web",
         featured: true,
+        techDescriptions: {
+            "Next.js": "Full-stack app with API routes",
+            "Puppeteer": "Headless browser for web scraping",
+            "Prisma": "Type-safe ORM for workflow storage",
+            "OpenAI": "AI-powered CSS selector extraction",
+        },
     },
     {
         name: "Hearty-Foods - Food delivery app",
@@ -26,6 +37,12 @@ export const PROJECTS: Project[] = [
         githubLink: "https://github.com/itsraghul/hearty-foods",
         websiteLink: "https://hearty-foods.vercel.app/",
         category: "web",
+        techDescriptions: {
+            "Next.js": "Server-side rendering & routing",
+            "MongoDB": "Menu items & order data storage",
+            "Cloudinary": "Dish image upload & CDN delivery",
+            "Paypal API": "Secure payment processing",
+        },
     },
     {
         name: "MediNet - Decentralized Medical Network",
@@ -34,6 +51,12 @@ export const PROJECTS: Project[] = [
         githubLink: "https://github.com/itsraghul/medi-net",
         websiteLink: "https://medinet.vercel.app/",
         category: "blockchain",
+        techDescriptions: {
+            "Next.js": "Frontend app & patient dashboard",
+            "Ethereum": "Smart contracts for record ownership",
+            "Web3": "Wallet connection & contract calls",
+            "IPFS": "Decentralized medical file storage",
+        },
     },
     {
         name: "CampFund - Decentralized Funding Network",
@@ -42,6 +65,12 @@ export const PROJECTS: Project[] = [
         githubLink: "https://github.com/itsraghul/camp-fund",
         websiteLink: "https://my-camp-fund.vercel.app/",
         category: "blockchain",
+        techDescriptions: {
+            "Next.js": "Campaign UI & contributor dashboard",
+            "Ethereum": "Fund transfers via Rinkeby testnet",
+            "Solidity": "Contract factory for each campaign",
+            "Azure": "Azure Bot for customer support",
+        },
     },
     {
         name: "RS Blockchain - A miniature blockchain",
@@ -50,6 +79,10 @@ export const PROJECTS: Project[] = [
         githubLink: "https://github.com/itsraghul/rs-blockchain/",
         websiteLink: "",
         category: "tools",
+        techDescriptions: {
+            "Javascript": "Core blockchain & mining logic",
+            "Redis": "Pub-sub for peer-to-peer transactions",
+        },
     },
     {
         name: "TriviaWebApp",
@@ -58,6 +91,11 @@ export const PROJECTS: Project[] = [
         githubLink: "https://github.com/itsraghul/TriviaWebApp",
         websiteLink: "https://trivia-web-app.vercel.app/",
         category: "web",
+        techDescriptions: {
+            "Javascript": "Quiz logic & score tracking",
+            "HTML": "Semantic markup & accessibility",
+            "CSS": "Styling & responsive layout",
+        },
     },
     {
         name: "Cosmic Breakout- Endless Runner Mobile Game",
@@ -66,5 +104,8 @@ export const PROJECTS: Project[] = [
         githubLink: "https://github.com/itsraghul/CosmicBreakoutGameAndroid",
         websiteLink: "",
         category: "game",
+        techDescriptions: {
+            "GDevelop5": "No-code game engine for Android build",
+        },
     },
 ];

--- a/public/audio/README.txt
+++ b/public/audio/README.txt
@@ -1,0 +1,1 @@
+# Place space-ambient.mp3 here (royalty-free, CC0)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -93,6 +93,10 @@ const config: Config = {
 					'66%': { transform: 'translate(-20px, 20px) scale(0.9)' },
 					'100%': { transform: 'translate(0px, 0px) scale(1)' },
 				},
+				'cursor-blink': {
+					'0%, 100%': { opacity: '1' },
+					'50%': { opacity: '0' },
+				},
 			},
 			animation: {
 				'accordion-down': 'accordion-down 0.2s ease-out',
@@ -101,6 +105,7 @@ const config: Config = {
 				blink: 'blink 0.7s step-end infinite',
 				fadeIn: 'fadeIn 6s',
 				blob: 'blob 7s infinite',
+				'cursor-blink': 'cursor-blink 1s step-end infinite',
 			}
 		}
 	},

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,6 +8,7 @@ export type Project = {
     websiteLink?: string;
     category?: string;
     featured?: boolean;
+    techDescriptions?: Record<string, string>;
 }
 
 


### PR DESCRIPTION
## Summary

- **Interactive Terminal** (`/terminal`): full-screen fake shell with commands (`help`, `whoami`, `ls`, `cat experience`, `open <project>`, `neofetch`), accessible via a terminal icon in the NavBar on both desktop and mobile
- **Custom Cursor & Magnetic Buttons**: spring-physics two-layer cursor with a lagging ring; NavBar links and Footer icons use `MagneticWrapper` to pull toward the cursor on hover
- **3D Cinematic Camera Intro**: on first visit to `/skills`, the camera flies in from a far position using smoothstep easing — gated by `sessionStorage` so it only plays once per session
- **"Currently Building" Banner**: dismissible top banner with a live pulsing dot, `localStorage`-persisted dismissal, toggled via `CURRENTLY_BUILDING.active` in constants
- **Reading Progress on `/about`**: fixed vertical progress bar scoped to the about page content; **Tech stack tooltips on project cards** showing per-tech usage descriptions; **Ambient space sound toggle** on `/skills` with Web Audio API fade in/out

## Test plan
- [ ] Visit `/terminal` and run `help`, `ls projects/`, `cat experience`, `open mock data`, `neofetch`
- [ ] Confirm terminal icon appears in NavBar (desktop + mobile hamburger menu)
- [ ] Confirm magnetic pull on NavBar links and Footer icons (desktop only)
- [ ] Visit `/skills` in a fresh session — camera should fly in; revisiting should skip intro
- [ ] Dismiss the building banner; confirm it stays dismissed on refresh
- [ ] Scroll `/about` and confirm reading progress bar fills
- [ ] Hover tech pills on project cards and confirm tooltips appear
- [ ] Toggle sound button on `/skills` (requires `public/audio/space-ambient.mp3` to be added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)