### PR TITLE
Add interactive game mode to home page with draggable bento grid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
-import HeroSection from "@/components/landing/HeroSection";
-import StatsBar from "@/components/landing/StatsBar";
-import FeaturedWork from "@/components/landing/FeaturedWork";
-import QuickLinks from "@/components/landing/QuickLinks";
 import JsonLd from "@/components/JsonLd";
+import GameHomeClient from "@/components/landing/GameHomeClient";
 
 export const metadata: Metadata = {
   title: "Raghul S — Founding Engineer @ Velt",
@@ -34,12 +31,7 @@ export default function Home() {
   return (
     <>
       <JsonLd data={personSchema} />
-      <div className="w-full">
-        <HeroSection />
-        <StatsBar />
-        <FeaturedWork />
-        <QuickLinks />
-      </div>
+      <GameHomeClient />
     </>
   );
 }

--- a/components/landing/GameHomeClient.tsx
+++ b/components/landing/GameHomeClient.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { AnimatePresence } from "framer-motion";
+import { useGameState } from "@/hooks/use-game-state";
+import { useEasterEggs } from "@/hooks/use-easter-eggs";
+import { useGravityPhysics } from "@/hooks/use-gravity-physics";
+import { BENTO_BLOCKS } from "@/constants/game";
+import HeroSection from "@/components/landing/HeroSection";
+import StatsBar from "@/components/landing/StatsBar";
+import FeaturedWork from "@/components/landing/FeaturedWork";
+import QuickLinks from "@/components/landing/QuickLinks";
+import BentoGrid from "@/components/landing/game/BentoGrid";
+import GameModeBar from "@/components/landing/game/GameModeBar";
+import ScoreDisplay from "@/components/landing/game/ScoreDisplay";
+import PuzzleComplete from "@/components/landing/game/PuzzleComplete";
+
+export default function GameHomeClient() {
+  const { state, dispatch, isGameActive, correctCount, setMode } = useGameState();
+
+  const { handleBlockClick, handleBlockHoverStart, handleBlockHoverEnd } = useEasterEggs({
+    dispatch,
+    revealedEggs: state.revealedEggs,
+    isGameActive,
+  });
+
+  const { positions: gravityPositions } = useGravityPhysics(
+    state.blockOrder,
+    state.mode === "gravity"
+  );
+
+  return (
+    <>
+      {/* Normal mode: original layout */}
+      {!isGameActive && (
+        <div className="w-full">
+          <HeroSection />
+          <StatsBar />
+          <FeaturedWork />
+          <QuickLinks />
+        </div>
+      )}
+
+      {/* Game mode: bento grid */}
+      {isGameActive && (
+        <>
+          <BentoGrid
+            state={state}
+            dispatch={dispatch}
+            onBlockClick={handleBlockClick}
+            onBlockHoverStart={handleBlockHoverStart}
+            onBlockHoverEnd={handleBlockHoverEnd}
+            gravityPositions={state.mode === "gravity" ? gravityPositions : undefined}
+          />
+
+          <AnimatePresence>
+            <ScoreDisplay
+              score={state.score}
+              moveCount={state.moveCount}
+              startTime={state.startTime}
+              correctCount={correctCount}
+              totalBlocks={BENTO_BLOCKS.length}
+              isPuzzleMode={state.mode === "puzzle"}
+            />
+          </AnimatePresence>
+
+          <PuzzleComplete
+            isVisible={state.puzzleSolved}
+            score={state.score}
+            moveCount={state.moveCount}
+            startTime={state.startTime}
+            onModeChange={setMode}
+          />
+        </>
+      )}
+
+      {/* Always show the game mode bar */}
+      <GameModeBar currentMode={state.mode} onModeChange={setMode} />
+    </>
+  );
+}

--- a/components/landing/game/BentoBlock.tsx
+++ b/components/landing/game/BentoBlock.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { HelpCircleIcon } from "lucide-react";
+import type { BlockId, BlockSize } from "@/types/game";
+import { cn } from "@/lib/utils";
+
+interface BentoBlockProps {
+  id: BlockId;
+  size: BlockSize;
+  label: string;
+  isFlipped: boolean;
+  isDraggable: boolean;
+  onFlip?: () => void;
+  onClick?: () => void;
+  onHoverStart?: () => void;
+  onHoverEnd?: () => void;
+  onBlockDragEnd?: (id: BlockId, event: MouseEvent | TouchEvent | PointerEvent) => void;
+  gravityPosition?: { x: number; y: number };
+  children: React.ReactNode;
+}
+
+const SIZE_CLASSES: Record<BlockSize, string> = {
+  "1x1": "col-span-1 row-span-1",
+  "2x1": "col-span-2 row-span-1",
+  "2x2": "col-span-2 row-span-2",
+};
+
+export default function BentoBlock({
+  id,
+  size,
+  label,
+  isFlipped,
+  isDraggable,
+  onFlip,
+  onClick,
+  onHoverStart,
+  onHoverEnd,
+  onBlockDragEnd,
+  gravityPosition,
+  children,
+}: BentoBlockProps) {
+  const handleClick = () => {
+    if (isFlipped && onFlip) {
+      onFlip();
+      return;
+    }
+    onClick?.();
+  };
+
+  return (
+    <motion.div
+      layout
+      layoutId={id}
+      drag={isDraggable && !isFlipped}
+      dragSnapToOrigin
+      dragElastic={0.2}
+      whileDrag={{ scale: 1.05, zIndex: 50, boxShadow: "0 25px 50px rgba(0,0,0,0.25)" }}
+      onDragEnd={(_, info) => {
+        // Use the pointer event from the info's point
+        const event = new PointerEvent("pointerup", {
+          clientX: info.point.x,
+          clientY: info.point.y,
+        });
+        onBlockDragEnd?.(id, event);
+      }}
+      whileHover={isDraggable ? { scale: 1.02 } : undefined}
+      onClick={handleClick}
+      onHoverStart={onHoverStart}
+      onHoverEnd={onHoverEnd}
+      animate={
+        gravityPosition
+          ? { x: gravityPosition.x, y: gravityPosition.y }
+          : undefined
+      }
+      className={cn(
+        SIZE_CLASSES[size],
+        "relative rounded-xl border border-border/50 bg-card/50 backdrop-blur-md overflow-hidden transition-colors",
+        isDraggable && "cursor-grab active:cursor-grabbing",
+        "hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5",
+        "[perspective:800px]"
+      )}
+      style={{ minHeight: size === "2x2" ? 280 : 130 }}
+      data-cursor="hover"
+      data-block-id={id}
+    >
+      {/* Front face */}
+      <motion.div
+        className="absolute inset-0"
+        animate={{ rotateY: isFlipped ? 180 : 0 }}
+        transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        style={{ backfaceVisibility: "hidden" }}
+      >
+        {children}
+      </motion.div>
+
+      {/* Back face (flipped state) */}
+      <motion.div
+        className="absolute inset-0 flex flex-col items-center justify-center bg-card/80 backdrop-blur-md"
+        animate={{ rotateY: isFlipped ? 0 : -180 }}
+        transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        style={{ backfaceVisibility: "hidden" }}
+      >
+        <HelpCircleIcon className="w-8 h-8 text-muted-foreground/50 mb-2" />
+        <span className="text-xs font-mono text-muted-foreground/50">{label}</span>
+        <span className="text-[10px] font-mono text-muted-foreground/30 mt-1">Click to reveal</span>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/components/landing/game/BentoGrid.tsx
+++ b/components/landing/game/BentoGrid.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+import { BriefcaseIcon, CpuIcon, FolderOpenIcon } from "lucide-react";
+import { FEATURED_STATS } from "@/constants";
+import { PROJECTS } from "@/constants/projects";
+import { BENTO_BLOCKS } from "@/constants/game";
+import type { BlockId, GameState, GameAction } from "@/types/game";
+import BentoBlock from "./BentoBlock";
+import HeroNameBlock from "./blocks/HeroNameBlock";
+import HeroCtaBlock from "./blocks/HeroCtaBlock";
+import StatBlock from "./blocks/StatBlock";
+import ProjectBlock from "./blocks/ProjectBlock";
+import QuickLinkBlock from "./blocks/QuickLinkBlock";
+
+const FEATURED_PROJECTS = PROJECTS.slice(0, 3);
+
+const QUICK_LINKS = [
+  { title: "Experience", description: "My professional journey", href: "/experience", icon: BriefcaseIcon },
+  { title: "Skills", description: "Technologies I work with", href: "/about", icon: CpuIcon },
+  { title: "Projects", description: "Things I've built", href: "/projects", icon: FolderOpenIcon },
+] as const;
+
+interface BentoGridProps {
+  state: GameState;
+  dispatch: React.Dispatch<GameAction>;
+  onBlockClick?: (id: BlockId) => void;
+  onBlockHoverStart?: (id: string) => void;
+  onBlockHoverEnd?: (id: string) => void;
+  gravityPositions?: Map<BlockId, { x: number; y: number }>;
+}
+
+function renderBlockContent(id: BlockId) {
+  switch (id) {
+    case "hero-name":
+      return <HeroNameBlock />;
+    case "hero-cta":
+      return <HeroCtaBlock />;
+    case "stat-experience":
+      return <StatBlock value={FEATURED_STATS[0].value} suffix={FEATURED_STATS[0].suffix} label={FEATURED_STATS[0].label} />;
+    case "stat-projects":
+      return <StatBlock value={FEATURED_STATS[1].value} suffix={FEATURED_STATS[1].suffix} label={FEATURED_STATS[1].label} />;
+    case "stat-technologies":
+      return <StatBlock value={FEATURED_STATS[2].value} suffix={FEATURED_STATS[2].suffix} label={FEATURED_STATS[2].label} />;
+    case "project-1":
+      return <ProjectBlock project={FEATURED_PROJECTS[0]} />;
+    case "project-2":
+      return <ProjectBlock project={FEATURED_PROJECTS[1]} />;
+    case "project-3":
+      return <ProjectBlock project={FEATURED_PROJECTS[2]} />;
+    case "quick-experience":
+      return <QuickLinkBlock {...QUICK_LINKS[0]} />;
+    case "quick-skills":
+      return <QuickLinkBlock {...QUICK_LINKS[1]} />;
+    case "quick-projects":
+      return <QuickLinkBlock {...QUICK_LINKS[2]} />;
+  }
+}
+
+export default function BentoGrid({
+  state,
+  dispatch,
+  onBlockClick,
+  onBlockHoverStart,
+  onBlockHoverEnd,
+  gravityPositions,
+}: BentoGridProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const isDraggable = state.mode !== "normal";
+
+  const handleDragEnd = useCallback(
+    (draggedId: BlockId, event: MouseEvent | TouchEvent | PointerEvent) => {
+      if (!gridRef.current) return;
+
+      // Find which block element we're over
+      const point = "touches" in event
+        ? { x: (event as TouchEvent).changedTouches[0].clientX, y: (event as TouchEvent).changedTouches[0].clientY }
+        : { x: (event as MouseEvent).clientX, y: (event as MouseEvent).clientY };
+
+      const elements = document.elementsFromPoint(point.x, point.y);
+      const targetBlock = elements.find(
+        (el) => el.getAttribute("data-block-id") && el.getAttribute("data-block-id") !== draggedId
+      );
+
+      if (targetBlock) {
+        const targetId = targetBlock.getAttribute("data-block-id") as BlockId;
+        const fromIndex = state.blockOrder.indexOf(draggedId);
+        const toIndex = state.blockOrder.indexOf(targetId);
+        if (fromIndex !== -1 && toIndex !== -1) {
+          dispatch({ type: "SWAP_BLOCKS", fromIndex, toIndex });
+        }
+      }
+    },
+    [state.blockOrder, dispatch]
+  );
+
+  return (
+    <div className="relative max-w-5xl mx-auto px-4 py-8">
+      {/* Background blobs */}
+      <div className="absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute top-1/4 -left-20 w-72 h-72 bg-purple-500/20 dark:bg-purple-500/10 rounded-full blur-[80px] animate-blob" />
+        <div className="absolute top-1/3 right-0 w-96 h-96 bg-cyan-500/20 dark:bg-cyan-500/10 rounded-full blur-[80px] animate-blob animation-delay-2000" />
+        <div className="absolute bottom-1/4 left-1/3 w-80 h-80 bg-pink-500/15 dark:bg-pink-500/8 rounded-full blur-[80px] animate-blob animation-delay-4000" />
+      </div>
+
+      <div
+        ref={gridRef}
+        className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4"
+      >
+        {state.blockOrder.map((id) => {
+          const config = BENTO_BLOCKS.find((b) => b.id === id)!;
+          const isFlipped = state.flippedBlocks.has(id);
+
+          return (
+            <BentoBlock
+              key={id}
+              id={id}
+              size={config.size}
+              label={config.label}
+              isFlipped={isFlipped}
+              isDraggable={isDraggable}
+              onFlip={() => dispatch({ type: "FLIP_BLOCK", id })}
+              onClick={() => onBlockClick?.(id)}
+              onHoverStart={() => onBlockHoverStart?.(id)}
+              onHoverEnd={() => onBlockHoverEnd?.(id)}
+              onBlockDragEnd={handleDragEnd}
+              gravityPosition={gravityPositions?.get(id)}
+            >
+              {renderBlockContent(id)}
+            </BentoBlock>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/landing/game/GameModeBar.tsx
+++ b/components/landing/game/GameModeBar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { motion } from "framer-motion";
+import {
+  BriefcaseIcon,
+  PuzzleIcon,
+  ArrowDownIcon,
+  MoveIcon,
+  GamepadIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import type { GameMode } from "@/types/game";
+import { cn } from "@/lib/utils";
+
+interface GameModeBarProps {
+  currentMode: GameMode;
+  onModeChange: (mode: GameMode) => void;
+}
+
+const MODES: { mode: GameMode; icon: React.ElementType; label: string }[] = [
+  { mode: "normal", icon: BriefcaseIcon, label: "Normal" },
+  { mode: "puzzle", icon: PuzzleIcon, label: "Puzzle" },
+  { mode: "gravity", icon: ArrowDownIcon, label: "Gravity" },
+  { mode: "freestyle", icon: MoveIcon, label: "Freestyle" },
+];
+
+export default function GameModeBar({ currentMode, onModeChange }: GameModeBarProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 40 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.5, duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50"
+    >
+      <div className="flex items-center gap-1 px-2 py-2 rounded-2xl border border-border/50 bg-card/80 backdrop-blur-xl shadow-2xl">
+        <div className="flex items-center gap-1 px-2">
+          <GamepadIcon className="w-4 h-4 text-muted-foreground" />
+          <Badge variant="outline" className="font-mono text-[10px] hidden sm:inline-flex">
+            {currentMode}
+          </Badge>
+        </div>
+
+        <div className="w-px h-6 bg-border/50 mx-1" />
+
+        {MODES.map(({ mode, icon: Icon, label }) => (
+          <Button
+            key={mode}
+            variant={currentMode === mode ? "default" : "ghost"}
+            size="sm"
+            onClick={() => onModeChange(mode)}
+            className={cn(
+              "font-mono text-xs gap-1.5 h-8",
+              currentMode === mode && "shadow-md"
+            )}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">{label}</span>
+          </Button>
+        ))}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/landing/game/PuzzleComplete.tsx
+++ b/components/landing/game/PuzzleComplete.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { PartyPopperIcon, RotateCcwIcon, EyeIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { GameMode } from "@/types/game";
+
+interface PuzzleCompleteProps {
+  isVisible: boolean;
+  score: number;
+  moveCount: number;
+  startTime: number | null;
+  onModeChange: (mode: GameMode) => void;
+}
+
+const CONFETTI_COLORS = [
+  "bg-red-500", "bg-blue-500", "bg-green-500", "bg-yellow-500",
+  "bg-purple-500", "bg-pink-500", "bg-cyan-500", "bg-orange-500",
+];
+
+function ConfettiParticle({ index }: { index: number }) {
+  const color = CONFETTI_COLORS[index % CONFETTI_COLORS.length];
+  const randomX = (Math.random() - 0.5) * 600;
+  const randomDelay = Math.random() * 0.5;
+  const size = 4 + Math.random() * 8;
+
+  return (
+    <motion.div
+      className={`absolute rounded-full ${color}`}
+      style={{ width: size, height: size, left: "50%", top: "40%" }}
+      initial={{ opacity: 1, x: 0, y: 0, rotate: 0 }}
+      animate={{
+        opacity: 0,
+        x: randomX,
+        y: 300 + Math.random() * 200,
+        rotate: 720 * (Math.random() > 0.5 ? 1 : -1),
+      }}
+      transition={{ duration: 2 + Math.random(), delay: randomDelay, ease: "easeOut" }}
+    />
+  );
+}
+
+export default function PuzzleComplete({
+  isVisible,
+  score,
+  moveCount,
+  startTime,
+  onModeChange,
+}: PuzzleCompleteProps) {
+  const elapsed = startTime ? Math.floor((Date.now() - startTime) / 1000) : 0;
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-background/60 backdrop-blur-sm"
+        >
+          {/* Confetti */}
+          {Array.from({ length: 40 }).map((_, i) => (
+            <ConfettiParticle key={i} index={i} />
+          ))}
+
+          <motion.div
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: "spring", bounce: 0.4, delay: 0.2 }}
+            className="relative max-w-sm mx-4 p-8 rounded-2xl border border-border/50 bg-card/90 backdrop-blur-xl text-center shadow-2xl"
+          >
+            <PartyPopperIcon className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
+            <h2 className="text-2xl font-bold font-mono mb-2">Puzzle Complete!</h2>
+            <p className="text-sm text-muted-foreground mb-6">
+              You arranged all the blocks correctly!
+            </p>
+
+            <div className="grid grid-cols-3 gap-4 mb-6">
+              <div className="flex flex-col items-center">
+                <span className="text-2xl font-bold font-mono text-primary">{score}</span>
+                <span className="text-[10px] font-mono text-muted-foreground">Score</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <span className="text-2xl font-bold font-mono text-primary">{moveCount}</span>
+                <span className="text-[10px] font-mono text-muted-foreground">Moves</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <span className="text-2xl font-bold font-mono text-primary">{elapsed}s</span>
+                <span className="text-[10px] font-mono text-muted-foreground">Time</span>
+              </div>
+            </div>
+
+            <div className="flex gap-2 justify-center">
+              <Button
+                onClick={() => onModeChange("puzzle")}
+                variant="outline"
+                size="sm"
+                className="font-mono text-xs"
+              >
+                <RotateCcwIcon className="w-3 h-3 mr-1" /> Play Again
+              </Button>
+              <Button
+                onClick={() => onModeChange("normal")}
+                size="sm"
+                className="font-mono text-xs"
+              >
+                <EyeIcon className="w-3 h-3 mr-1" /> View Portfolio
+              </Button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/landing/game/ScoreDisplay.tsx
+++ b/components/landing/game/ScoreDisplay.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { useState, useEffect, useRef } from "react";
+import { TrophyIcon, MoveIcon, TimerIcon } from "lucide-react";
+import type { ScorePopup } from "@/types/game";
+
+interface ScoreDisplayProps {
+  score: number;
+  moveCount: number;
+  startTime: number | null;
+  correctCount: number;
+  totalBlocks: number;
+  isPuzzleMode: boolean;
+}
+
+export default function ScoreDisplay({
+  score,
+  moveCount,
+  startTime,
+  correctCount,
+  totalBlocks,
+  isPuzzleMode,
+}: ScoreDisplayProps) {
+  const [popups, setPopups] = useState<ScorePopup[]>([]);
+  const prevScore = useRef(score);
+  const [elapsed, setElapsed] = useState(0);
+
+  // Score pop-up animation
+  useEffect(() => {
+    const diff = score - prevScore.current;
+    if (diff > 0) {
+      const popup: ScorePopup = {
+        id: `${Date.now()}-${Math.random()}`,
+        points: diff,
+        x: 0,
+        y: 0,
+      };
+      setPopups((prev) => [...prev, popup]);
+      setTimeout(() => {
+        setPopups((prev) => prev.filter((p) => p.id !== popup.id));
+      }, 1000);
+    }
+    prevScore.current = score;
+  }, [score]);
+
+  // Elapsed time counter
+  useEffect(() => {
+    if (!startTime || !isPuzzleMode) return;
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startTime) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [startTime, isPuzzleMode]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className="fixed top-20 right-4 z-40 flex flex-col items-end gap-2"
+    >
+      {/* Score */}
+      <div className="relative flex items-center gap-2 px-4 py-2 rounded-xl border border-border/50 bg-card/80 backdrop-blur-md">
+        <TrophyIcon className="w-4 h-4 text-yellow-500" />
+        <span className="font-mono text-sm font-bold">{score}</span>
+
+        <AnimatePresence>
+          {popups.map((popup) => (
+            <motion.span
+              key={popup.id}
+              initial={{ opacity: 1, y: 0 }}
+              animate={{ opacity: 0, y: -30 }}
+              exit={{ opacity: 0 }}
+              className="absolute -top-2 right-2 text-xs font-mono font-bold text-green-500"
+            >
+              +{popup.points}
+            </motion.span>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      {/* Moves */}
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 bg-card/80 backdrop-blur-md">
+        <MoveIcon className="w-3 h-3 text-muted-foreground" />
+        <span className="font-mono text-xs">{moveCount} moves</span>
+      </div>
+
+      {/* Timer (puzzle mode) */}
+      {isPuzzleMode && (
+        <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 bg-card/80 backdrop-blur-md">
+          <TimerIcon className="w-3 h-3 text-muted-foreground" />
+          <span className="font-mono text-xs">{elapsed}s</span>
+        </div>
+      )}
+
+      {/* Progress (puzzle mode) */}
+      {isPuzzleMode && (
+        <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 bg-card/80 backdrop-blur-md">
+          <span className="font-mono text-xs text-muted-foreground">
+            {correctCount}/{totalBlocks} correct
+          </span>
+          <div className="w-16 h-1.5 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300"
+              style={{ width: `${(correctCount / totalBlocks) * 100}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/components/landing/game/blocks/HeroCtaBlock.tsx
+++ b/components/landing/game/blocks/HeroCtaBlock.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { HOMEPAGE_INFO } from "@/constants";
+import { Button } from "@/components/ui/button";
+
+export default function HeroCtaBlock() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3 p-4">
+      <p className="text-xs sm:text-sm text-muted-foreground/80 text-center line-clamp-2">
+        {HOMEPAGE_INFO.BASIC_DESC}
+      </p>
+      <div className="flex gap-2">
+        <Button asChild size="sm" className="font-mono text-xs">
+          <Link href={HOMEPAGE_INFO.CTA_PRIMARY.href}>
+            {HOMEPAGE_INFO.CTA_PRIMARY.label}
+          </Link>
+        </Button>
+        <Button asChild variant="outline" size="sm" className="font-mono text-xs backdrop-blur-sm">
+          <a href={HOMEPAGE_INFO.CTA_SECONDARY.href} target="_blank" rel="noopener noreferrer">
+            {HOMEPAGE_INFO.CTA_SECONDARY.label}
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/landing/game/blocks/HeroNameBlock.tsx
+++ b/components/landing/game/blocks/HeroNameBlock.tsx
@@ -1,0 +1,19 @@
+import { HOMEPAGE_INFO } from "@/constants";
+
+export default function HeroNameBlock() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center p-4">
+      <span className="inline-block px-3 py-1 rounded-full text-xs font-mono border border-border/60 bg-secondary/50 backdrop-blur-sm text-muted-foreground mb-3">
+        {HOMEPAGE_INFO.ROLE}
+      </span>
+      <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight mb-2">
+        <span className="bg-gradient-to-r from-foreground via-foreground/80 to-foreground/60 bg-clip-text text-transparent">
+          {HOMEPAGE_INFO.NAME_INFO.replace("I'm ", "")}
+        </span>
+      </h1>
+      <p className="text-sm sm:text-base text-muted-foreground font-mono max-w-xs">
+        {HOMEPAGE_INFO.TAGLINE}
+      </p>
+    </div>
+  );
+}

--- a/components/landing/game/blocks/ProjectBlock.tsx
+++ b/components/landing/game/blocks/ProjectBlock.tsx
@@ -1,0 +1,46 @@
+import { Code2Icon, EarthIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { openLink } from "@/lib/utils";
+import type { Project } from "@/types";
+
+interface ProjectBlockProps {
+  project: Project;
+}
+
+export default function ProjectBlock({ project }: ProjectBlockProps) {
+  return (
+    <div className="flex flex-col h-full p-4">
+      <h3 className="text-sm font-bold font-mono mb-1 text-primary truncate">
+        {project.name.split(" - ")[0]}
+      </h3>
+      <p className="text-[10px] font-mono text-muted-foreground mb-2 truncate">
+        {project.stack}
+      </p>
+      <p className="text-xs text-muted-foreground/80 flex-1 line-clamp-2 mb-2">
+        {project.description}
+      </p>
+      <div className="flex gap-1">
+        {project.githubLink && (
+          <Button
+            onClick={() => openLink(project.githubLink!)}
+            variant="ghost"
+            size="sm"
+            className="font-mono text-[10px] h-6 px-2"
+          >
+            <Code2Icon className="w-3 h-3 mr-1" /> Code
+          </Button>
+        )}
+        {project.websiteLink && (
+          <Button
+            onClick={() => openLink(project.websiteLink!)}
+            variant="ghost"
+            size="sm"
+            className="font-mono text-[10px] h-6 px-2"
+          >
+            <EarthIcon className="w-3 h-3 mr-1" /> Live
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/landing/game/blocks/QuickLinkBlock.tsx
+++ b/components/landing/game/blocks/QuickLinkBlock.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+
+interface QuickLinkBlockProps {
+  title: string;
+  description: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+export default function QuickLinkBlock({ title, description, href, icon: Icon }: QuickLinkBlockProps) {
+  return (
+    <Link
+      href={href}
+      className="flex flex-col items-center justify-center h-full p-4 text-center group"
+    >
+      <Icon className="w-6 h-6 text-muted-foreground group-hover:text-primary transition-colors mb-2" />
+      <h3 className="text-sm font-bold font-mono mb-0.5">{title}</h3>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </Link>
+  );
+}

--- a/components/landing/game/blocks/StatBlock.tsx
+++ b/components/landing/game/blocks/StatBlock.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useRef, useEffect, useState } from "react";
+import { useInView } from "framer-motion";
+
+interface StatBlockProps {
+  value: number;
+  suffix: string;
+  label: string;
+}
+
+function CountUp({ value, suffix }: { value: number; suffix: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true });
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!isInView) return;
+    let start = 0;
+    const duration = 1500;
+    const step = duration / value;
+    const timer = setInterval(() => {
+      start += 1;
+      setCount(start);
+      if (start >= value) clearInterval(timer);
+    }, step);
+    return () => clearInterval(timer);
+  }, [isInView, value]);
+
+  return (
+    <span ref={ref}>
+      {count}{suffix}
+    </span>
+  );
+}
+
+export default function StatBlock({ value, suffix, label }: StatBlockProps) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-4">
+      <span className="text-3xl sm:text-4xl font-bold font-mono text-primary">
+        <CountUp value={value} suffix={suffix} />
+      </span>
+      <span className="text-xs text-muted-foreground mt-1 font-mono text-center">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -1,0 +1,34 @@
+import type { BentoBlockConfig, BlockId, EasterEgg } from "@/types/game";
+
+export const BENTO_BLOCKS: BentoBlockConfig[] = [
+  { id: "hero-name", label: "Identity", size: "2x2", correctPosition: 0 },
+  { id: "hero-cta", label: "Connect", size: "2x1", correctPosition: 1 },
+  { id: "stat-experience", label: "Years", size: "1x1", correctPosition: 2 },
+  { id: "stat-projects", label: "Projects", size: "1x1", correctPosition: 3 },
+  { id: "stat-technologies", label: "Tech", size: "1x1", correctPosition: 4 },
+  { id: "project-1", label: "Mock Data", size: "1x1", correctPosition: 5 },
+  { id: "project-2", label: "DataForge", size: "1x1", correctPosition: 6 },
+  { id: "project-3", label: "Hearty Foods", size: "1x1", correctPosition: 7 },
+  { id: "quick-experience", label: "Experience", size: "1x1", correctPosition: 8 },
+  { id: "quick-skills", label: "Skills", size: "2x1", correctPosition: 9 },
+  { id: "quick-projects", label: "Projects", size: "1x1", correctPosition: 10 },
+];
+
+export const CORRECT_ORDER: BlockId[] = BENTO_BLOCKS.map((b) => b.id);
+
+export const SCORE_VALUES = {
+  DRAG_BLOCK: 10,
+  FLIP_CARD: 15,
+  CORRECT_PLACEMENT: 25,
+  EASTER_EGG: 100,
+  PUZZLE_COMPLETE: 500,
+} as const;
+
+export const PUZZLE_FLIPPED_COUNT = 4;
+
+export const EASTER_EGGS: EasterEgg[] = [
+  { id: "konami", trigger: "konami", description: "Entered the Konami Code!", points: 100 },
+  { id: "triple-click-name", trigger: "click-count", description: "Found the secret triple-click!", points: 50 },
+  { id: "shake-device", trigger: "shake", description: "Shook things up!", points: 75 },
+  { id: "hover-patience", trigger: "hover-duration", description: "Patience is a virtue!", points: 50 },
+];

--- a/hooks/use-easter-eggs.ts
+++ b/hooks/use-easter-eggs.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import type { GameAction, BlockId } from "@/types/game";
+import { EASTER_EGGS } from "@/constants/game";
+import { toast } from "sonner";
+
+const KONAMI_SEQUENCE = [
+  "ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown",
+  "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight",
+  "KeyB", "KeyA",
+];
+
+interface UseEasterEggsProps {
+  dispatch: React.Dispatch<GameAction>;
+  revealedEggs: Set<string>;
+  isGameActive: boolean;
+}
+
+export function useEasterEggs({ dispatch, revealedEggs, isGameActive }: UseEasterEggsProps) {
+  const konamiIndex = useRef(0);
+  const clickCounts = useRef(new Map<BlockId, number>());
+  const hoverTimers = useRef(new Map<string, NodeJS.Timeout>());
+
+  const revealEgg = useCallback(
+    (eggId: string) => {
+      const egg = EASTER_EGGS.find((e) => e.id === eggId);
+      if (!egg || revealedEggs.has(eggId)) return;
+      dispatch({ type: "REVEAL_EGG", eggId, points: egg.points });
+      toast.success(`Easter Egg: ${egg.description}`, {
+        description: `+${egg.points} points!`,
+      });
+    },
+    [dispatch, revealedEggs]
+  );
+
+  // Konami code listener
+  useEffect(() => {
+    if (!isGameActive) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.code === KONAMI_SEQUENCE[konamiIndex.current]) {
+        konamiIndex.current++;
+        if (konamiIndex.current === KONAMI_SEQUENCE.length) {
+          revealEgg("konami");
+          konamiIndex.current = 0;
+        }
+      } else {
+        konamiIndex.current = 0;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isGameActive, revealEgg]);
+
+  // Device shake detection (mobile)
+  useEffect(() => {
+    if (!isGameActive) return;
+
+    let lastX = 0, lastY = 0, lastZ = 0;
+    let shakeCount = 0;
+    const threshold = 15;
+
+    const handleMotion = (e: DeviceMotionEvent) => {
+      const acc = e.accelerationIncludingGravity;
+      if (!acc?.x || !acc?.y || !acc?.z) return;
+
+      const deltaX = Math.abs(acc.x - lastX);
+      const deltaY = Math.abs(acc.y - lastY);
+      const deltaZ = Math.abs(acc.z - lastZ);
+
+      if (deltaX + deltaY + deltaZ > threshold) {
+        shakeCount++;
+        if (shakeCount > 3) {
+          revealEgg("shake-device");
+          shakeCount = 0;
+        }
+      }
+
+      lastX = acc.x;
+      lastY = acc.y;
+      lastZ = acc.z;
+    };
+
+    window.addEventListener("devicemotion", handleMotion);
+    return () => window.removeEventListener("devicemotion", handleMotion);
+  }, [isGameActive, revealEgg]);
+
+  const handleBlockClick = useCallback(
+    (blockId: BlockId) => {
+      if (!isGameActive) return;
+      const count = (clickCounts.current.get(blockId) || 0) + 1;
+      clickCounts.current.set(blockId, count);
+
+      if (blockId === "hero-name" && count >= 3) {
+        revealEgg("triple-click-name");
+        clickCounts.current.set(blockId, 0);
+      }
+
+      // Reset after a delay
+      setTimeout(() => clickCounts.current.set(blockId, 0), 1000);
+    },
+    [isGameActive, revealEgg]
+  );
+
+  const handleBlockHoverStart = useCallback(
+    (blockId: string) => {
+      if (!isGameActive) return;
+      const timer = setTimeout(() => revealEgg("hover-patience"), 10000);
+      hoverTimers.current.set(blockId, timer);
+    },
+    [isGameActive, revealEgg]
+  );
+
+  const handleBlockHoverEnd = useCallback((blockId: string) => {
+    const timer = hoverTimers.current.get(blockId);
+    if (timer) {
+      clearTimeout(timer);
+      hoverTimers.current.delete(blockId);
+    }
+  }, []);
+
+  return { handleBlockClick, handleBlockHoverStart, handleBlockHoverEnd };
+}

--- a/hooks/use-game-state.ts
+++ b/hooks/use-game-state.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useReducer, useCallback } from "react";
+import type { GameState, GameAction, GameMode, BlockId } from "@/types/game";
+import { CORRECT_ORDER, SCORE_VALUES, PUZZLE_FLIPPED_COUNT } from "@/constants/game";
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const shuffled = [...arr];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+function pickRandomItems<T>(arr: T[], count: number): T[] {
+  const shuffled = shuffleArray(arr);
+  return shuffled.slice(0, count);
+}
+
+function isPuzzleSolved(order: BlockId[]): boolean {
+  return order.every((id, i) => id === CORRECT_ORDER[i]);
+}
+
+function createInitialState(mode: GameMode = "normal"): GameState {
+  const blockOrder = mode === "puzzle" ? shuffleArray([...CORRECT_ORDER]) : [...CORRECT_ORDER];
+  const flippedBlocks = new Set<BlockId>(
+    mode === "puzzle" ? pickRandomItems([...CORRECT_ORDER], PUZZLE_FLIPPED_COUNT) : []
+  );
+
+  return {
+    mode,
+    score: 0,
+    blockOrder,
+    flippedBlocks,
+    revealedEggs: new Set(),
+    puzzleSolved: false,
+    moveCount: 0,
+    startTime: mode === "puzzle" ? Date.now() : null,
+  };
+}
+
+function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case "SET_MODE":
+      return createInitialState(action.mode);
+
+    case "SWAP_BLOCKS": {
+      const newOrder = [...state.blockOrder];
+      [newOrder[action.fromIndex], newOrder[action.toIndex]] = [
+        newOrder[action.toIndex],
+        newOrder[action.fromIndex],
+      ];
+      const correctBonus =
+        newOrder[action.toIndex] === CORRECT_ORDER[action.toIndex]
+          ? SCORE_VALUES.CORRECT_PLACEMENT
+          : 0;
+      const scoreAdd = state.mode === "puzzle" ? SCORE_VALUES.DRAG_BLOCK + correctBonus : 0;
+      const solved = state.mode === "puzzle" && isPuzzleSolved(newOrder);
+
+      return {
+        ...state,
+        blockOrder: newOrder,
+        moveCount: state.moveCount + 1,
+        score: state.score + scoreAdd + (solved ? SCORE_VALUES.PUZZLE_COMPLETE : 0),
+        puzzleSolved: solved,
+      };
+    }
+
+    case "FLIP_BLOCK": {
+      const newFlipped = new Set(state.flippedBlocks);
+      newFlipped.delete(action.id);
+      return {
+        ...state,
+        flippedBlocks: newFlipped,
+        score: state.score + (state.mode === "puzzle" ? SCORE_VALUES.FLIP_CARD : 0),
+      };
+    }
+
+    case "REVEAL_EGG": {
+      if (state.revealedEggs.has(action.eggId)) return state;
+      const newEggs = new Set(state.revealedEggs);
+      newEggs.add(action.eggId);
+      return { ...state, revealedEggs: newEggs, score: state.score + action.points };
+    }
+
+    case "ADD_SCORE":
+      return { ...state, score: state.score + action.points };
+
+    case "RESET":
+      return createInitialState("normal");
+
+    default:
+      return state;
+  }
+}
+
+export function useGameState() {
+  const [state, dispatch] = useReducer(gameReducer, "normal", createInitialState);
+
+  const isGameActive = state.mode !== "normal";
+
+  const correctCount = state.blockOrder.reduce(
+    (count, id, i) => count + (id === CORRECT_ORDER[i] ? 1 : 0),
+    0
+  );
+
+  const setMode = useCallback((mode: GameMode) => dispatch({ type: "SET_MODE", mode }), []);
+
+  return { state, dispatch, isGameActive, correctCount, setMode };
+}

--- a/hooks/use-gravity-physics.ts
+++ b/hooks/use-gravity-physics.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { BlockId } from "@/types/game";
+
+interface PhysicsBody {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  width: number;
+  height: number;
+}
+
+const GRAVITY = 0.5;
+const DAMPING = 0.7;
+const FLOOR_Y = 600;
+
+export function useGravityPhysics(
+  blockOrder: BlockId[],
+  isActive: boolean
+) {
+  const [positions, setPositions] = useState<Map<BlockId, { x: number; y: number }>>(new Map());
+  const bodiesRef = useRef<Map<BlockId, PhysicsBody>>(new Map());
+  const rafRef = useRef<number>(0);
+
+  const initBodies = useCallback(() => {
+    const bodies = new Map<BlockId, PhysicsBody>();
+    blockOrder.forEach((id, i) => {
+      const col = i % 4;
+      const row = Math.floor(i / 4);
+      bodies.set(id, {
+        x: col * 200,
+        y: row * 180,
+        vx: (Math.random() - 0.5) * 4,
+        vy: 0,
+        width: 180,
+        height: 160,
+      });
+    });
+    bodiesRef.current = bodies;
+  }, [blockOrder]);
+
+  useEffect(() => {
+    if (!isActive) {
+      setPositions(new Map());
+      cancelAnimationFrame(rafRef.current);
+      return;
+    }
+
+    initBodies();
+
+    const step = () => {
+      const newPositions = new Map<BlockId, { x: number; y: number }>();
+
+      bodiesRef.current.forEach((body, id) => {
+        body.vy += GRAVITY;
+        body.x += body.vx;
+        body.y += body.vy;
+
+        // Floor collision
+        if (body.y + body.height > FLOOR_Y) {
+          body.y = FLOOR_Y - body.height;
+          body.vy *= -DAMPING;
+          body.vx *= 0.95;
+          if (Math.abs(body.vy) < 1) body.vy = 0;
+        }
+
+        // Wall collision
+        if (body.x < 0) { body.x = 0; body.vx *= -DAMPING; }
+        if (body.x + body.width > 800) { body.x = 800 - body.width; body.vx *= -DAMPING; }
+
+        newPositions.set(id, { x: body.x, y: body.y });
+      });
+
+      // Simple inter-body collision
+      const entries = Array.from(bodiesRef.current.entries());
+      for (let i = 0; i < entries.length; i++) {
+        for (let j = i + 1; j < entries.length; j++) {
+          const [, a] = entries[i];
+          const [, b] = entries[j];
+          if (
+            a.x < b.x + b.width && a.x + a.width > b.x &&
+            a.y < b.y + b.height && a.y + a.height > b.y
+          ) {
+            const overlapY = Math.min(a.y + a.height - b.y, b.y + b.height - a.y);
+            if (a.y < b.y) {
+              a.y -= overlapY / 2;
+              b.y += overlapY / 2;
+            } else {
+              a.y += overlapY / 2;
+              b.y -= overlapY / 2;
+            }
+            const tempVy = a.vy;
+            a.vy = b.vy * DAMPING;
+            b.vy = tempVy * DAMPING;
+          }
+        }
+      }
+
+      setPositions(newPositions);
+      rafRef.current = requestAnimationFrame(step);
+    };
+
+    rafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [isActive, initBodies]);
+
+  const applyForce = useCallback((id: BlockId, fx: number, fy: number) => {
+    const body = bodiesRef.current.get(id);
+    if (body) {
+      body.vx += fx;
+      body.vy += fy;
+    }
+  }, []);
+
+  return { positions, applyForce };
+}

--- a/lib/animations.ts
+++ b/lib/animations.ts
@@ -35,3 +35,19 @@ export const DEFAULT_TRANSITION = {
 };
 
 export const VIEWPORT_ONCE = { once: true, amount: 0.3 as const };
+
+export const cardFlip: Variants = {
+  front: { rotateY: 0, transition: { duration: 0.6 } },
+  back: { rotateY: 180, transition: { duration: 0.6 } },
+};
+
+export const scorePopUp: Variants = {
+  initial: { opacity: 0, y: 0, scale: 0.5 },
+  animate: { opacity: 1, y: -30, scale: 1 },
+  exit: { opacity: 0, y: -60 },
+};
+
+export const puzzleComplete: Variants = {
+  hidden: { opacity: 0, scale: 0.8 },
+  visible: { opacity: 1, scale: 1, transition: { type: "spring", bounce: 0.4 } },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -97,6 +97,14 @@ const config: Config = {
 					'0%, 100%': { opacity: '1' },
 					'50%': { opacity: '0' },
 				},
+				'float-up': {
+					'0%': { opacity: '1', transform: 'translateY(0)' },
+					'100%': { opacity: '0', transform: 'translateY(-40px)' },
+				},
+				confetti: {
+					'0%': { transform: 'translateY(0) rotate(0deg)', opacity: '1' },
+					'100%': { transform: 'translateY(300px) rotate(720deg)', opacity: '0' },
+				},
 			},
 			animation: {
 				'accordion-down': 'accordion-down 0.2s ease-out',
@@ -106,6 +114,8 @@ const config: Config = {
 				fadeIn: 'fadeIn 6s',
 				blob: 'blob 7s infinite',
 				'cursor-blink': 'cursor-blink 1s step-end infinite',
+			'float-up': 'float-up 1s ease-out forwards',
+			confetti: 'confetti 2s ease-out forwards',
 			}
 		}
 	},

--- a/types/game.ts
+++ b/types/game.ts
@@ -1,0 +1,56 @@
+export type BlockId =
+  | "hero-name"
+  | "hero-cta"
+  | "stat-experience"
+  | "stat-projects"
+  | "stat-technologies"
+  | "project-1"
+  | "project-2"
+  | "project-3"
+  | "quick-experience"
+  | "quick-skills"
+  | "quick-projects";
+
+export type BlockSize = "1x1" | "2x1" | "2x2";
+
+export interface BentoBlockConfig {
+  id: BlockId;
+  label: string;
+  size: BlockSize;
+  correctPosition: number;
+}
+
+export type GameMode = "normal" | "puzzle" | "gravity" | "freestyle";
+
+export interface GameState {
+  mode: GameMode;
+  score: number;
+  blockOrder: BlockId[];
+  flippedBlocks: Set<BlockId>;
+  revealedEggs: Set<string>;
+  puzzleSolved: boolean;
+  moveCount: number;
+  startTime: number | null;
+}
+
+export type GameAction =
+  | { type: "SET_MODE"; mode: GameMode }
+  | { type: "SWAP_BLOCKS"; fromIndex: number; toIndex: number }
+  | { type: "FLIP_BLOCK"; id: BlockId }
+  | { type: "REVEAL_EGG"; eggId: string; points: number }
+  | { type: "ADD_SCORE"; points: number }
+  | { type: "RESET" };
+
+export interface EasterEgg {
+  id: string;
+  trigger: "click-count" | "konami" | "hover-duration" | "shake";
+  description: string;
+  points: number;
+}
+
+export interface ScorePopup {
+  id: string;
+  points: number;
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
## Summary
- Transforms the home page into an interactive bento grid with 4 game modes: Normal (original layout), Puzzle (shuffled blocks to solve), Gravity (physics simulation), and Freestyle (free drag)
- Decomposes 4 monolithic sections into 11 draggable blocks with card flip, scoring, timer, and confetti celebration on puzzle completion
- Adds easter egg detection (Konami code, triple-click, long hover, device shake) with toast notifications and bonus points
- Floating game mode toolbar and score HUD with animated point pop-ups, always accessible at the bottom of the page

## Test plan
- [ ] Verify Normal mode renders original portfolio layout unchanged
- [ ] Test Puzzle mode: blocks shuffle, flipped cards can be clicked to reveal, drag-to-swap works, score increments, puzzle completion triggers confetti overlay
- [ ] Test Gravity mode: blocks fall with physics, bounce off floor and each other
- [ ] Test Freestyle mode: free drag without scoring
- [ ] Test responsive layout on mobile (2-column grid)
- [ ] Verify easter eggs: Konami code sequence, triple-click name block, 10s hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)