### PR TITLE
Fix game toolbar centering and bento grid layout

### DIFF
--- a/components/landing/game/BentoGrid.tsx
+++ b/components/landing/game/BentoGrid.tsx
@@ -95,7 +95,7 @@ export default function BentoGrid({
   );
 
   return (
-    <div className="relative max-w-5xl mx-auto px-4 py-8">
+    <div className="relative w-full max-w-5xl mx-auto px-4 py-8">
       {/* Background blobs */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
         <div className="absolute top-1/4 -left-20 w-72 h-72 bg-purple-500/20 dark:bg-purple-500/10 rounded-full blur-[80px] animate-blob" />

--- a/components/landing/game/GameModeBar.tsx
+++ b/components/landing/game/GameModeBar.tsx
@@ -27,12 +27,12 @@ const MODES: { mode: GameMode; icon: React.ElementType; label: string }[] = [
 
 export default function GameModeBar({ currentMode, onModeChange }: GameModeBarProps) {
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 40 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: 0.5, duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
-      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50"
-    >
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50">
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5, duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+      >
       <div className="flex items-center gap-1 px-2 py-2 rounded-2xl border border-border/50 bg-card/80 backdrop-blur-xl shadow-2xl">
         <div className="flex items-center gap-1 px-2">
           <GamepadIcon className="w-4 h-4 text-muted-foreground" />
@@ -59,6 +59,7 @@ export default function GameModeBar({ currentMode, onModeChange }: GameModeBarPr
           </Button>
         ))}
       </div>
-    </motion.div>
+      </motion.div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix the game mode toolbar not being horizontally centered by separating the fixed positioning wrapper from the framer-motion animated element — framer-motion's `y` transform was overwriting Tailwind's `-translate-x-1/2`
- Fix puzzle/gravity/freestyle modes rendering a compressed narrow strip by adding `w-full` to the BentoGrid container, which was collapsing inside the flex-row `<main>`

## Test plan
- [ ] Verify toolbar is horizontally centered at the bottom in all modes
- [ ] Switch to Puzzle mode — grid should render at full width with 4 columns
- [ ] Switch to Gravity mode — blocks should span full width before falling
- [ ] Switch to Freestyle mode — same full-width grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)