### PR TITLE
Fix hop game platform layout and camera initialization

### DIFF
--- a/components/landing/game/HopPlatform.tsx
+++ b/components/landing/game/HopPlatform.tsx
@@ -36,16 +36,21 @@ export default function HopPlatform({
       data-block-id={config.blockId}
     >
       {/* Scaled-down bento content */}
-      <div
-        className="origin-top-left pointer-events-none"
-        style={{
-          transform: `scale(${config.height > 50 ? 0.35 : 0.3})`,
-          width: config.width / 0.3,
-          height: config.height / 0.3,
-        }}
-      >
-        {children}
-      </div>
+      {(() => {
+        const scale = config.height > 50 ? 0.35 : 0.3;
+        return (
+          <div
+            className="origin-top-left pointer-events-none"
+            style={{
+              transform: `scale(${scale})`,
+              width: config.width / scale,
+              height: config.height / scale,
+            }}
+          >
+            {children}
+          </div>
+        );
+      })()}
 
       {/* Platform label overlay */}
       <div className="absolute inset-0 flex items-center justify-center">

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -32,21 +32,24 @@ export const GAME_HEIGHT = 600;
 export const CHAR_SIZE = 48;
 
 // Platform layout for hop mode — bottom to top
-// Y values increase upward; 0 is the ground level
+// In CSS, larger Y = lower on screen. Platform 0 is at the bottom (large Y),
+// Platform 10 is at the top (small Y). Character hops upward toward smaller Y values.
 const PLATFORM_SPACING = 130;
+const TOTAL_PLATFORMS = 10;
+const WORLD_BASE_Y = TOTAL_PLATFORMS * PLATFORM_SPACING; // 1300 — world bottom
 
 export const PLATFORM_CONFIGS: PlatformConfig[] = [
-  { blockId: "hero-name",         x: 200, y: 0 * PLATFORM_SPACING,  width: 400, height: 60, behavior: "static" },
-  { blockId: "hero-cta",          x: 250, y: 1 * PLATFORM_SPACING,  width: 300, height: 50, behavior: "static" },
-  { blockId: "stat-experience",   x: 80,  y: 2 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "static" },
-  { blockId: "stat-projects",     x: 500, y: 3 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "horizontal", moveRange: 150, moveSpeed: 1.5 },
-  { blockId: "stat-technologies", x: 200, y: 4 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "static" },
-  { blockId: "project-1",         x: 450, y: 5 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "horizontal", moveRange: 150, moveSpeed: 1.2 },
-  { blockId: "project-2",         x: 100, y: 6 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "vertical",   moveRange: 30,  moveSpeed: 1.0 },
-  { blockId: "project-3",         x: 350, y: 7 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "horizontal", moveRange: 120, moveSpeed: 1.8 },
-  { blockId: "quick-experience",  x: 150, y: 8 * PLATFORM_SPACING,  width: 150, height: 40, behavior: "static" },
-  { blockId: "quick-skills",      x: 250, y: 9 * PLATFORM_SPACING,  width: 300, height: 50, behavior: "vertical",   moveRange: 20,  moveSpeed: 0.8 },
-  { blockId: "quick-projects",    x: 300, y: 10 * PLATFORM_SPACING, width: 150, height: 40, behavior: "static" },
+  { blockId: "hero-name",         x: 200, y: WORLD_BASE_Y - 0  * PLATFORM_SPACING, width: 400, height: 60, behavior: "static" },
+  { blockId: "hero-cta",          x: 250, y: WORLD_BASE_Y - 1  * PLATFORM_SPACING, width: 300, height: 50, behavior: "static" },
+  { blockId: "stat-experience",   x: 80,  y: WORLD_BASE_Y - 2  * PLATFORM_SPACING, width: 150, height: 40, behavior: "static" },
+  { blockId: "stat-projects",     x: 500, y: WORLD_BASE_Y - 3  * PLATFORM_SPACING, width: 150, height: 40, behavior: "horizontal", moveRange: 150, moveSpeed: 1.5 },
+  { blockId: "stat-technologies", x: 200, y: WORLD_BASE_Y - 4  * PLATFORM_SPACING, width: 150, height: 40, behavior: "static" },
+  { blockId: "project-1",         x: 450, y: WORLD_BASE_Y - 5  * PLATFORM_SPACING, width: 150, height: 40, behavior: "horizontal", moveRange: 150, moveSpeed: 1.2 },
+  { blockId: "project-2",         x: 100, y: WORLD_BASE_Y - 6  * PLATFORM_SPACING, width: 150, height: 40, behavior: "vertical",   moveRange: 30,  moveSpeed: 1.0 },
+  { blockId: "project-3",         x: 350, y: WORLD_BASE_Y - 7  * PLATFORM_SPACING, width: 150, height: 40, behavior: "horizontal", moveRange: 120, moveSpeed: 1.8 },
+  { blockId: "quick-experience",  x: 150, y: WORLD_BASE_Y - 8  * PLATFORM_SPACING, width: 150, height: 40, behavior: "static" },
+  { blockId: "quick-skills",      x: 250, y: WORLD_BASE_Y - 9  * PLATFORM_SPACING, width: 300, height: 50, behavior: "vertical",   moveRange: 20,  moveSpeed: 0.8 },
+  { blockId: "quick-projects",    x: 300, y: WORLD_BASE_Y - 10 * PLATFORM_SPACING, width: 150, height: 40, behavior: "static" },
 ];
 
 export const HOP_SCORE = {

--- a/hooks/use-hop-physics.ts
+++ b/hooks/use-hop-physics.ts
@@ -5,6 +5,10 @@ import type { BlockId, PlatformConfig } from "@/types/game";
 import { PLATFORM_CONFIGS, GAME_WIDTH, CHAR_SIZE, HOP_SCORE } from "@/constants/game";
 import type { HopInput } from "./use-hop-controls";
 
+// Initial camera position: frames the starting character near the lower third of the viewport
+const INITIAL_CHAR_Y = PLATFORM_CONFIGS[0].y - CHAR_SIZE;
+const INITIAL_CAMERA_Y = INITIAL_CHAR_Y - 350;
+
 const GRAVITY = 0.6;
 const JUMP_VEL = -13;
 const MOVE_SPEED = 5;
@@ -47,8 +51,8 @@ export function useHopPhysics(
 ) {
   const [physicsState, setPhysicsState] = useState<HopPhysicsState>(() => createInitialPhysicsState());
   const charRef = useRef<CharacterState>(createInitialChar());
-  const cameraYRef = useRef(0);
-  const maxCameraYRef = useRef(0);
+  const cameraYRef = useRef(INITIAL_CAMERA_Y);
+  const maxCameraYRef = useRef(INITIAL_CAMERA_Y);
   const visitedPlatformsRef = useRef(new Set<number>([0]));
   const highestIdxRef = useRef(0);
   const gameOverRef = useRef(false);
@@ -60,8 +64,8 @@ export function useHopPhysics(
 
   const restart = useCallback(() => {
     charRef.current = createInitialChar();
-    cameraYRef.current = 0;
-    maxCameraYRef.current = 0;
+    cameraYRef.current = INITIAL_CAMERA_Y;
+    maxCameraYRef.current = INITIAL_CAMERA_Y;
     visitedPlatformsRef.current = new Set([0]);
     highestIdxRef.current = 0;
     gameOverRef.current = false;
@@ -241,7 +245,7 @@ function createInitialPhysicsState(): HopPhysicsState {
     characterVel: { vx: 0, vy: 0 },
     isGrounded: true,
     facingRight: true,
-    cameraY: 0,
+    cameraY: INITIAL_CAMERA_Y,
     platformPositions: computePlatformPositions(0),
     isGameOver: false,
     isComplete: false,


### PR DESCRIPTION
## Summary
- Platform Y coordinates were ascending (0→1300), causing all 11 blocks to stack top-to-bottom within the visible 600px viewport instead of being spread across a tall scrollable world
- Reversed platform Y values using a `WORLD_BASE_Y` anchor so platform 0 sits at the bottom of the world and the character hops upward toward smaller Y values
- Camera now initializes to `INITIAL_CAMERA_Y` (derived from the starting character position) instead of `0`, which placed the character off-screen above the viewport
- Fixed a scale/size mismatch in `HopPlatform` where `transform: scale()` used `0.35` for taller blocks but the container dimensions divided by `0.3`, causing content overflow

## Test plan
- [ ] Switch to "Hop" game mode — character appears on the starting platform near the bottom of the game viewport
- [ ] Only 3–4 platforms visible initially, spread across the viewport
- [ ] Jumping upward causes camera to follow smoothly (ratchet prevents scrolling back down)
- [ ] Falling off triggers game over screen; reaching top platform triggers victory screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)