### PR TITLE
fix: resolve skills page crash after Next.js 15 upgrade

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,22 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    transpilePackages: ['three'],
+    transpilePackages: ['three', '@react-three/fiber', '@react-three/drei'],
+    webpack: (config, { isServer }) => {
+        if (!isServer) {
+            config.resolve.alias = {
+                ...config.resolve.alias,
+                react: path.resolve(__dirname, 'node_modules/react'),
+                'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
+                scheduler: path.resolve(__dirname, 'node_modules/scheduler'),
+            };
+        }
+        return config;
+    },
     images: {
     localPatterns: [
       {


### PR DESCRIPTION
## Summary

- Fixes the client-side `TypeError: Cannot read properties of undefined (reading 'ReactCurrentBatchConfig')` that crashes the `/skills` page
- Root cause: Next.js 15's changed webpack bundling caused `react-reconciler` inside `@react-three/fiber` to resolve a different React instance in dynamically-imported chunks
- Adds `@react-three/fiber` and `@react-three/drei` to `transpilePackages` and enforces a single React instance via client-side webpack aliases for `react`, `react-dom`, and `scheduler`

## Test plan

- [ ] Visit `/skills` — 3D scene should load without crash
- [ ] Check browser console for absence of `ReactCurrentBatchConfig` error
- [ ] Verify other pages (home, experience, projects, about) still work